### PR TITLE
add open in editor action for service (#3)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative;
+
+public class Constants {
+    public static final String STRUCTURE_PROPERTY = Constants.class.getPackage().getName() + ".structure";
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
@@ -13,15 +13,20 @@ package com.redhat.devtools.intellij.knative;
 import com.intellij.ide.util.treeView.AbstractTreeStructure;
 import com.intellij.ide.util.treeView.NodeRenderer;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.ActionGroup;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.ui.PopupHandler;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.StructureTreeModel;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.tree.MutableModelSynchronizer;
+import com.redhat.devtools.intellij.knative.listener.TreePopupMenuListener;
 import com.redhat.devtools.intellij.knative.tree.KnTreeStructure;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,8 +43,11 @@ public class WindowToolFactory implements ToolWindowFactory {
             StructureTreeModel<KnTreeStructure> model = buildModel(structure, project);
             new MutableModelSynchronizer<>(model, structure, structure);
             Tree tree = new Tree(new AsyncTreeModel(model, project));
+            tree.putClientProperty(Constants.STRUCTURE_PROPERTY, structure);
             tree.setCellRenderer(new NodeRenderer());
-
+            ActionManager actionManager = ActionManager.getInstance();
+            ActionGroup group = (ActionGroup)actionManager.getAction("com.redhat.devtools.intellij.knative.tree");
+            PopupHandler.installPopupHandler(tree, group, ActionPlaces.UNKNOWN, actionManager, new TreePopupMenuListener());
             toolWindow.getContentManager().addContent(contentFactory.createContent(new JBScrollPane(tree), "", false));
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException | NoSuchMethodException e) {
             throw new RuntimeException((e));

--- a/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.ui.ClickListener;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.content.ContentFactory;
@@ -26,8 +27,10 @@ import com.intellij.ui.tree.AsyncTreeModel;
 import com.intellij.ui.tree.StructureTreeModel;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.tree.MutableModelSynchronizer;
+import com.redhat.devtools.intellij.knative.listener.TreeDoubleClickListener;
 import com.redhat.devtools.intellij.knative.listener.TreePopupMenuListener;
 import com.redhat.devtools.intellij.knative.tree.KnTreeStructure;
+import java.awt.event.MouseEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Constructor;
@@ -49,6 +52,7 @@ public class WindowToolFactory implements ToolWindowFactory {
             ActionGroup group = (ActionGroup)actionManager.getAction("com.redhat.devtools.intellij.knative.tree");
             PopupHandler.installPopupHandler(tree, group, ActionPlaces.UNKNOWN, actionManager, new TreePopupMenuListener());
             toolWindow.getContentManager().addContent(contentFactory.createContent(new JBScrollPane(tree), "", false));
+            new TreeDoubleClickListener(tree);
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException | NoSuchMethodException e) {
             throw new RuntimeException((e));
         }

--- a/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
@@ -19,7 +19,6 @@ import com.intellij.openapi.actionSystem.ActionPlaces;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
-import com.intellij.ui.ClickListener;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.content.ContentFactory;
@@ -30,11 +29,9 @@ import com.redhat.devtools.intellij.common.tree.MutableModelSynchronizer;
 import com.redhat.devtools.intellij.knative.listener.TreeDoubleClickListener;
 import com.redhat.devtools.intellij.knative.listener.TreePopupMenuListener;
 import com.redhat.devtools.intellij.knative.tree.KnTreeStructure;
-import java.awt.event.MouseEvent;
-import org.jetbrains.annotations.NotNull;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import org.jetbrains.annotations.NotNull;
 
 public class WindowToolFactory implements ToolWindowFactory {
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/KnAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/KnAction.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.ui.treeStructure.Tree;
+import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
+import com.redhat.devtools.intellij.knative.Constants;
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.tree.KnRootNode;
+import com.redhat.devtools.intellij.knative.tree.KnTreeStructure;
+import java.io.IOException;
+import javax.swing.tree.TreePath;
+
+public class KnAction  extends StructureTreeAction {
+
+    public KnAction(Class... filters) {
+        super(filters);
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected) {
+        try {
+            this.actionPerformed(anActionEvent, path, selected, getTkn(anActionEvent));
+        } catch (IOException e) {
+            Messages.showErrorDialog("Error: " + e.getLocalizedMessage(), "Error");
+        }
+    }
+
+    private Kn getTkn(AnActionEvent anActionEvent) throws IOException {
+        Tree tree = getTree(anActionEvent);
+        return ((KnRootNode)((KnTreeStructure)tree.getClientProperty(Constants.STRUCTURE_PROPERTY)).getRootElement()).getKn();
+    }
+
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn tkn) {}
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/KnAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/KnAction.java
@@ -30,13 +30,13 @@ public class KnAction  extends StructureTreeAction {
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected) {
         try {
-            this.actionPerformed(anActionEvent, path, selected, getTkn(anActionEvent));
+            this.actionPerformed(anActionEvent, path, selected, getKn(anActionEvent));
         } catch (IOException e) {
             Messages.showErrorDialog("Error: " + e.getLocalizedMessage(), "Error");
         }
     }
 
-    private Kn getTkn(AnActionEvent anActionEvent) throws IOException {
+    private Kn getKn(AnActionEvent anActionEvent) throws IOException {
         Tree tree = getTree(anActionEvent);
         return ((KnRootNode)((KnTreeStructure)tree.getClientProperty(Constants.STRUCTURE_PROPERTY)).getRootElement()).getKn();
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/OpenInEditorAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/OpenInEditorAction.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.tree.KnServiceNode;
+import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import com.redhat.devtools.intellij.knative.utils.EditorHelper;
+import javax.swing.tree.TreePath;
+
+public class OpenInEditorAction extends KnAction {
+    public OpenInEditorAction() {
+        super(KnServiceNode.class);
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn tkncli) {
+        ParentableNode node = getElement(selected);
+        EditorHelper.openKnComponentInEditor(node);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/OpenInEditorAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/OpenInEditorAction.java
@@ -12,6 +12,7 @@ package com.redhat.devtools.intellij.knative.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.tree.KnRevisionNode;
 import com.redhat.devtools.intellij.knative.tree.KnServiceNode;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
 import com.redhat.devtools.intellij.knative.utils.EditorHelper;
@@ -19,7 +20,7 @@ import javax.swing.tree.TreePath;
 
 public class OpenInEditorAction extends KnAction {
     public OpenInEditorAction() {
-        super(KnServiceNode.class);
+        super(KnServiceNode.class, KnRevisionNode.class);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -41,7 +41,8 @@ public interface Kn {
     /**
      * Fetch the Service data
      *
-     * @return
+     * @return list of services
+     * @throws IOException if communication encountered an error
      */
     List<Service> getServicesList() throws IOException;
 
@@ -49,6 +50,17 @@ public interface Kn {
      * Return the list of all Knative Revisions for service
      *
      * @param serviceName the Knative service name
+     * @return list of revision belonging to service
+     * @throws IOException if communication encountered an error
      */
     List<Revision> getRevisionsForService(String serviceName) throws IOException;
+
+    /**
+     * Get the Service component as YAML
+     *
+     * @param name name of service
+     * @return service component as YAML
+     * @throws IOException if communication encountered an error
+     */
+    String getServiceYAML(String name) throws IOException;
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -63,4 +63,13 @@ public interface Kn {
      * @throws IOException if communication encountered an error
      */
     String getServiceYAML(String name) throws IOException;
+
+    /**
+     * Get the Revision component as YAML
+     *
+     * @param name name of revision
+     * @return revision component as YAML
+     * @throws IOException if communication encountered an error
+     */
+    String getRevisionYAML(String name) throws IOException;
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -91,6 +91,11 @@ public class KnCli implements Kn {
         return getCustomCollection(json, Revision.class);
     }
 
+    @Override
+    public String getServiceYAML(String name) throws IOException {
+        return ExecHelper.execute(command, envVars, "service", "describe", name, "-o", "yaml", "-n", getNamespace());
+    }
+
     private <T> List<T> getCustomCollection(String json, Class<T> customClass) throws IOException {
         if (!JSON_MAPPER.readTree(json).has("items")) return Collections.emptyList();
         if (JSON_MAPPER.readTree(json).get("items").isNull()) return Collections.emptyList();

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -96,6 +96,11 @@ public class KnCli implements Kn {
         return ExecHelper.execute(command, envVars, "service", "describe", name, "-o", "yaml", "-n", getNamespace());
     }
 
+    @Override
+    public String getRevisionYAML(String name) throws IOException {
+        return ExecHelper.execute(command, envVars, "revision", "describe", name, "-o", "yaml", "-n", getNamespace());
+    }
+
     private <T> List<T> getCustomCollection(String json, Class<T> customClass) throws IOException {
         if (!JSON_MAPPER.readTree(json).has("items")) return Collections.emptyList();
         if (JSON_MAPPER.readTree(json).get("items").isNull()) return Collections.emptyList();

--- a/src/main/java/com/redhat/devtools/intellij/knative/listener/TreeDoubleClickListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/listener/TreeDoubleClickListener.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.listener;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.DoubleClickListener;
+import com.intellij.util.ui.tree.WideSelectionTreeUI;
+import com.redhat.devtools.intellij.knative.utils.EditorHelper;
+import java.awt.event.MouseEvent;
+import javax.swing.JTree;
+import javax.swing.tree.TreePath;
+import org.jetbrains.annotations.NotNull;
+
+public class TreeDoubleClickListener extends DoubleClickListener {
+    private final JTree tree;
+
+    public TreeDoubleClickListener(final JTree tree) {
+        this.tree = tree;
+        installOn(tree);
+    }
+
+    @Override
+    protected boolean onDoubleClick(MouseEvent event) {
+        final TreePath clickPath = tree.getUI() instanceof WideSelectionTreeUI ? tree.getClosestPathForLocation(event.getX(), event.getY())
+                : tree.getPathForLocation(event.getX(), event.getY());
+        if (clickPath == null) {
+            return false;
+        }
+
+        final DataContext dataContext = DataManager.getInstance().getDataContext(tree);
+        final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+        if (project == null) {
+            return false;
+        }
+
+        TreePath selectionPath = tree.getSelectionPath();
+        if (!clickPath.equals(selectionPath)) {
+            return false;
+        }
+
+        if (event.getClickCount() == 2) {
+            processDoubleClick(selectionPath);
+            return true;
+        }
+        return false;
+    }
+
+    protected void processDoubleClick(@NotNull TreePath treePath) {
+        EditorHelper.openKnComponentInEditor(treePath);
+    }
+}
+

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.LightVirtualFile;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EditorHelper {
+    private static Logger logger = LoggerFactory.getLogger(EditorHelper.class);
+
+    public static void openKnComponentInEditor(ParentableNode node) {
+        if (node == null) {
+            return;
+        }
+
+        try {
+            String yaml = KnHelper.getYamlFromNode(node);
+            if (!yaml.isEmpty()) {
+                openVirtualFileInEditor(node.getRootNode().getProject(), node.getName() + ".yaml", yaml);
+            }
+        } catch (IOException e) {
+            logger.warn(e.getLocalizedMessage(), e);
+            UIHelper.executeInUI(() -> Messages.showErrorDialog("Error while opening knative component " + node.getName() + ": " + e.getLocalizedMessage(), "Error"));
+        }
+    }
+
+    public static void openVirtualFileInEditor(Project project, String name, String content) throws IOException {
+        Optional<FileEditor> editor = Arrays.stream(FileEditorManager.getInstance(project).getAllEditors())
+                                            .filter(fileEditor -> fileEditor.getFile().getName().startsWith(name))
+                                            .findFirst();
+        if (!editor.isPresent()) {
+            VirtualFile virtualFile = createVirtualFile(name, content);
+            FileEditorManager.getInstance(project).openFile(virtualFile, true);
+        } else {
+            Editor openedEditor = FileEditorManager.getInstance(project).openTextEditor(new OpenFileDescriptor(project, editor.get().getFile()), true);
+            updateVirtualFile(openedEditor.getDocument(), content);
+        }
+    }
+
+    public static VirtualFile createVirtualFile(String name, String content) throws IOException {
+        VirtualFile vf = new LightVirtualFile(name, content);
+        vf.setWritable(false);
+        return vf;
+    }
+
+    public static void updateVirtualFile(Document document, String newContent) {
+        /*if (document.getText().equalsIgnoreCase(newContent)) {
+            return;
+        }*/
+        ApplicationManager.getApplication().runWriteAction(() -> {
+            document.setReadOnly(false);
+            document.setText(newContent);
+            if (!document.isWritable()) {
+                document.setReadOnly(true);
+            }
+        });
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
@@ -68,9 +68,9 @@ public class EditorHelper {
     }
 
     public static void updateVirtualFile(Document document, String newContent) {
-        /*if (document.getText().equalsIgnoreCase(newContent)) {
+        if (document.getText().equalsIgnoreCase(newContent)) {
             return;
-        }*/
+        }
         ApplicationManager.getApplication().runWriteAction(() -> {
             document.setReadOnly(false);
             document.setText(newContent);

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
@@ -40,9 +40,7 @@ public class EditorHelper {
     }
 
     public static void openKnComponentInEditor(ParentableNode node) {
-        if (node == null) {
-            return;
-        }
+        if (node == null) return;
 
         try {
             String yaml = KnHelper.getYamlFromNode(node);

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
@@ -21,16 +21,23 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.LightVirtualFile;
+import com.redhat.devtools.intellij.common.actions.StructureTreeAction;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
+import javax.swing.tree.TreePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class EditorHelper {
     private static Logger logger = LoggerFactory.getLogger(EditorHelper.class);
+
+    public static void openKnComponentInEditor(TreePath path) {
+        ParentableNode node = StructureTreeAction.getElement(path.getLastPathComponent());
+        openKnComponentInEditor(node);
+    }
 
     public static void openKnComponentInEditor(ParentableNode node) {
         if (node == null) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/EditorHelper.java
@@ -13,7 +13,6 @@ package com.redhat.devtools.intellij.knative.utils;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/KnHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/KnHelper.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils;
+
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.tree.KnServiceNode;
+import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import java.io.IOException;
+
+public class KnHelper {
+
+    public static String getYamlFromNode(ParentableNode node) throws IOException {
+        Kn knCli = node.getRootNode().getKn();
+        String content = "";
+        if (node instanceof KnServiceNode) {
+            content = knCli.getServiceYAML(node.getName());
+        }
+        return content;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/KnHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/KnHelper.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.knative.utils;
 
 import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.tree.KnRevisionNode;
 import com.redhat.devtools.intellij.knative.tree.KnServiceNode;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
 import java.io.IOException;
@@ -22,6 +23,8 @@ public class KnHelper {
         String content = "";
         if (node instanceof KnServiceNode) {
             content = knCli.getServiceYAML(node.getName());
+        } else if (node instanceof KnRevisionNode) {
+            content = knCli.getRevisionYAML(node.getName());
         }
         return content;
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,8 @@
     </extensions>
 
     <actions>
-        <!-- Add your actions here -->
+        <group id="com.redhat.devtools.intellij.knative.tree" popup="true">
+            <action class="com.redhat.devtools.intellij.knative.actions.OpenInEditorAction" text="Open in Editor"/>
+        </group>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
it resolves #3 and #4

It allows to open both components `service` and `revision` as read-only as in vscode.
I also added the double click as in tekton.

EDIT: I missed the edit action in vscode, so basically they are first opened as read-only and if the user wants to edit them he needs to click on the edit action that open a new editor tab. Not sure if we want to copy vscode or we want to open the editor in edit mode directly. Ideas? We can also discuss it in #6 