### PR TITLE
Sort revisions based on their generation

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/WindowToolFactory.java
@@ -28,10 +28,12 @@ import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.common.tree.MutableModelSynchronizer;
 import com.redhat.devtools.intellij.knative.listener.TreeDoubleClickListener;
 import com.redhat.devtools.intellij.knative.listener.TreePopupMenuListener;
+import com.redhat.devtools.intellij.knative.tree.KnNodeComparator;
 import com.redhat.devtools.intellij.knative.tree.KnTreeStructure;
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import org.jetbrains.annotations.NotNull;
 
 public class WindowToolFactory implements ToolWindowFactory {
     @Override
@@ -41,6 +43,7 @@ public class WindowToolFactory implements ToolWindowFactory {
 
             KnTreeStructure structure = new KnTreeStructure(project);
             StructureTreeModel<KnTreeStructure> model = buildModel(structure, project);
+            model.setComparator(new KnNodeComparator<>());
             new MutableModelSynchronizer<>(model, structure, structure);
             Tree tree = new Tree(new AsyncTreeModel(model, project));
             tree.putClientProperty(Constants.STRUCTURE_PROPERTY, structure);

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/DeserializerUtil.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/DeserializerUtil.java
@@ -14,7 +14,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public class DeserializerUtil {
 
@@ -42,6 +45,18 @@ public class DeserializerUtil {
             result.add(new StatusCondition(lastTransitionTime, status, type, reason, message));
         }
 
+        return result;
+    }
+
+    public static Map<String, String> getStringMap(JsonNode jsonNode) {
+        if (jsonNode == null || !jsonNode.isObject()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new HashMap<>();
+        for (Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields(); it.hasNext(); ) {
+            Map.Entry<String, JsonNode> entry = it.next();
+            result.put(entry.getKey(), entry.getValue().textValue());
+        }
         return result;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnConstants.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.kn;
+
+public interface KnConstants {
+    /**
+     * Label
+     */
+    String CONFIGURATION_GENERATION = "serving.knative.dev/configurationGeneration";
+
+    /**
+     * Label
+     */
+    String CONFIGURATION = "serving.knative.dev/configuration";
+
+    /**
+     * Label
+     */
+    String ROUTING_STATE = "serving.knative.dev/routingState";
+
+    /**
+     * Label
+     */
+    String SERVICE = "serving.knative.dev/service";
+
+    /**
+     * Annotation
+     */
+    String USER_IMAGE = "client.knative.dev/user-image";
+
+    /**
+     * Annotation
+     */
+    String CREATOR = "serving.knative.dev/creator";
+
+    /**
+     * Annotation
+     */
+    String ROUTES = "serving.knative.dev/routes";
+
+    /**
+     * Annotation
+     */
+    String ROUTING_STATE_MODIFIED = "serving.knative.dev/routingStateModified";
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnConstants.java
@@ -10,44 +10,40 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.kn;
 
-public interface KnConstants {
+public final class KnConstants {
     /**
      * Label
      */
-    String CONFIGURATION_GENERATION = "serving.knative.dev/configurationGeneration";
-
+    public static final String CONFIGURATION_GENERATION = "serving.knative.dev/configurationGeneration";
     /**
      * Label
      */
-    String CONFIGURATION = "serving.knative.dev/configuration";
-
+    public static final String CONFIGURATION = "serving.knative.dev/configuration";
     /**
      * Label
      */
-    String ROUTING_STATE = "serving.knative.dev/routingState";
-
+    public static final String ROUTING_STATE = "serving.knative.dev/routingState";
     /**
      * Label
      */
-    String SERVICE = "serving.knative.dev/service";
-
+    public static final String SERVICE = "serving.knative.dev/service";
     /**
      * Annotation
      */
-    String USER_IMAGE = "client.knative.dev/user-image";
-
+    public static final String USER_IMAGE = "client.knative.dev/user-image";
     /**
      * Annotation
      */
-    String CREATOR = "serving.knative.dev/creator";
-
+    public static final String CREATOR = "serving.knative.dev/creator";
     /**
      * Annotation
      */
-    String ROUTES = "serving.knative.dev/routes";
-
+    public static final String ROUTES = "serving.knative.dev/routes";
     /**
      * Annotation
      */
-    String ROUTING_STATE_MODIFIED = "serving.knative.dev/routingStateModified";
+    public static final String ROUTING_STATE_MODIFIED = "serving.knative.dev/routingStateModified";
+
+    private KnConstants() {
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Revision.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Revision.java
@@ -11,8 +11,10 @@
 package com.redhat.devtools.intellij.knative.kn;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Map;
 
 @JsonDeserialize(using = RevisionDeserializer.class)
 public class Revision {
@@ -20,9 +22,17 @@ public class Revision {
 
     private List<StatusCondition> conditions;
 
-    public Revision(String name, List<StatusCondition> conditions) {
+    @NotNull
+    private Map<String, String> annotations;
+
+    @NotNull
+    private Map<String, String> labels;
+
+    public Revision(String name, List<StatusCondition> conditions, @NotNull Map<String, String> annotations, @NotNull Map<String, String> labels) {
         this.name = name;
         this.conditions = conditions;
+        this.annotations = annotations;
+        this.labels = labels;
     }
 
     public String getName() {
@@ -31,5 +41,25 @@ public class Revision {
 
     public List<StatusCondition> getConditions() {
         return conditions;
+    }
+
+    /**
+     * Annotations map, use {@link KnConstants} to get keys
+     *
+     * @return annotations map
+     */
+    @NotNull
+    public Map<String, String> getAnnotations() {
+        return annotations;
+    }
+
+    /**
+     * Labels map, use {@link KnConstants} to get keys
+     *
+     * @return labels map
+     */
+    @NotNull
+    public Map<String, String> getLabels() {
+        return labels;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/RevisionDeserializer.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/RevisionDeserializer.java
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer;
 
-import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class RevisionDeserializer extends StdNodeBasedDeserializer<Revision> {
     protected RevisionDeserializer() {
@@ -23,9 +23,11 @@ public class RevisionDeserializer extends StdNodeBasedDeserializer<Revision> {
     }
 
     @Override
-    public Revision convert(JsonNode root, DeserializationContext deserializationContext) throws IOException {
+    public Revision convert(JsonNode root, DeserializationContext deserializationContext) {
         String name = root.get("metadata").get("name").asText();
         List<StatusCondition> conditions = DeserializerUtil.getConvertToConditions(root.get("status").get("conditions"));
-        return new Revision(name, conditions);
+        Map<String, String> annotations = DeserializerUtil.getStringMap(root.get("metadata").get("annotations"));
+        Map<String, String> labels = DeserializerUtil.getStringMap(root.get("metadata").get("labels"));
+        return new Revision(name, conditions, annotations, labels);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnNodeComparator.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnNodeComparator.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.tree;
+
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.redhat.devtools.intellij.knative.kn.KnConstants;
+
+import java.util.Comparator;
+
+public class KnNodeComparator<T extends NodeDescriptor<?>> implements Comparator<T> {
+
+    @Override
+    public int compare(T o1, T o2) {
+        if (o1.equals(o2)) {
+            return 0;
+        }
+
+        if (o1 instanceof KnRevisionDescriptor && o2 instanceof KnRevisionDescriptor) {
+            // we comparing string witch contains number
+            return ((KnRevisionDescriptor) o2).getElement().getRevision().getLabels().get(KnConstants.CONFIGURATION_GENERATION).compareTo(
+                    ((KnRevisionDescriptor) o1).getElement().getRevision().getLabels().get(KnConstants.CONFIGURATION_GENERATION)
+            );
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnRevisionDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnRevisionDescriptor.java
@@ -20,6 +20,7 @@ import com.intellij.ui.SimpleTextAttributes;
 import com.redhat.devtools.intellij.knative.kn.ServiceStatus;
 import com.redhat.devtools.intellij.knative.kn.ServiceTraffic;
 import com.redhat.devtools.intellij.knative.kn.StatusCondition;
+import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -73,7 +74,7 @@ public class KnRevisionDescriptor extends PresentableNodeDescriptor<KnRevisionNo
             presentation.setTooltip("Revision: " + element.getName());
             presentation.addText(element.getName(), percent != 0 ? SimpleTextAttributes.REGULAR_ATTRIBUTES : WARNING_ATTRIBUTES);
         } else {
-            presentation.setTooltip(errorMessage.length() >= 100 ? errorMessage.substring(0, 100) + "..." : errorMessage);
+            presentation.setTooltip(TreeHelper.trimErrorMessage(errorMessage));
             presentation.addText(element.getName(), SimpleTextAttributes.ERROR_ATTRIBUTES);
         }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnServiceDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnServiceDescriptor.java
@@ -31,6 +31,7 @@ public class KnServiceDescriptor extends PresentableNodeDescriptor<KnServiceNode
         super(project, parentDescriptor);
         this.element = element;
         this.nodeIcon = nodeIcon;
+        this.myName = element.getName();
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/TreeHelper.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/TreeHelper.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils;
+
+public class TreeHelper {
+
+    private static final int MESSAGE_MAX_LENGTH = 130;
+
+    public static String trimErrorMessage(String errorMessage) {
+        return errorMessage.length() >= MESSAGE_MAX_LENGTH ? errorMessage.substring(0, MESSAGE_MAX_LENGTH) + "..." : errorMessage;
+    }
+}


### PR DESCRIPTION
This PR adds comparator for knative tree. 
It is sorting revisions nodes based on their `serving.knative.dev/configurationGeneration` label value.
Also highlight revisions which doesn't has traffic. 
And fix tag rendering, add space between labels.
Demo:

<img width="349" alt="Screenshot 2021-03-11 at 09 55 47" src="https://user-images.githubusercontent.com/929743/110754332-621d1600-8250-11eb-9a95-fd9af06991c7.png">


Fix: #12 