### PR TITLE
Add keybinding to Refresh and Delete action

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/RefreshAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/RefreshAction.java
@@ -35,6 +35,9 @@ public class RefreshAction extends StructureTreeAction {
             return;
         }
         KnTreeStructure structure = (KnTreeStructure) tree.getClientProperty(Constants.STRUCTURE_PROPERTY);
+        if (structure == null) {
+            return;
+        }
         if (Constants.TOOLBAR_PLACE.equals(anActionEvent.getPlace())) {
             structure.fireModified(structure.getRootElement());
         } else {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,10 +26,13 @@
         <group id="com.redhat.devtools.intellij.knative.tree" popup="true">
             <action class="com.redhat.devtools.intellij.knative.actions.OpenInEditorAction" text="Open in Editor"/>
             <action class="com.redhat.devtools.intellij.knative.actions.OpenInBrowserAction" text="Open in Browser"/>
-            <action class="com.redhat.devtools.intellij.knative.actions.DeleteAction" text="Delete"/>
+            <action class="com.redhat.devtools.intellij.knative.actions.DeleteAction" text="Delete"
+                    use-shortcut-of="$Delete">
+            </action>
             <action id="com.redhat.devtools.intellij.knative.refresh"
                     class="com.redhat.devtools.intellij.knative.actions.RefreshAction"
-                    text="Refresh" icon="AllIcons.Actions.Refresh"/>
+                    text="Refresh" icon="AllIcons.Actions.Refresh"
+                    use-shortcut-of="Refresh"/>
         </group>
 
         <group id="com.redhat.devtools.intellij.knativev.view.actionsToolbar">


### PR DESCRIPTION
This PR just common keybindings to `Delete` and `Refresh` actions.

Fix: #29 

To add custom keybinding we may use:
```xml
<action class="com.redhat.devtools.intellij.knative.actions.OpenInEditorAction" text="Open in Editor">
  <keyboard-shortcut first-keystroke="meta g" keymap="Mac OS X 10.5+"/>
<action>
```

By default IJ allows to edit keybinding for any action in preferences:
<img width="997" alt="Screenshot 2021-03-24 at 14 54 25" src="https://user-images.githubusercontent.com/929743/112313722-d58f4080-8cb0-11eb-8b52-fcf39acffe7b.png">


Depends on https://github.com/redhat-developer/intellij-common/pull/50