### PR TITLE
chore: add dependency to kubernetes plugin (#44)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def versionsMap = ['IU-2019.3':'193.5233.144','IU-2020.1':'201.6668.99', 'IU-202
 intellij {
     version ideaVersion
     pluginName 'Knative by Red Hat'
-    plugins 'terminal', 'yaml', 'com.intellij.kubernetes:' + versionsMap[ideaVersion]
+    plugins 'terminal', 'yaml', 'com.intellij.kubernetes:' + versionsMap[ideaVersion], 'com.redhat.devtools.intellij.kubernetes:0.1.6.32'
     updateSinceUntilBuild false
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
     <depends>org.jetbrains.plugins.terminal</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
+    <depends>com.redhat.devtools.intellij.kubernetes</depends>
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>
     <depends optional="true" config-file="plugin-kubernetes.xml">com.intellij.kubernetes</depends>
 


### PR DESCRIPTION
New IJ k8s release allows to switch namespace/project :rocket: 