### PR TITLE
feat: optimize update action with new common version (#31)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ intellij {
 }
 
 dependencies {
-    compile 'com.redhat.devtools.intellij:intellij-common:1.1.0-SNAPSHOT'
+    compile 'com.redhat.devtools.intellij:intellij-common:1.1.0'
     testCompile 'org.mockito:mockito-inline:3.8.0'
 
 


### PR DESCRIPTION
it resolves #31 

This PR uses the new IJ-common library 1.1.0. 
Now you can also edit labels/annotations for an existing resource from the editor. This is needed to change a public knative service to a private one by adding `networking.knative.dev/visibility=cluster-local` as label