### PR TITLE
feat: show notification when undeploy action is complete (#98)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/UndeployAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/UndeployAction.java
@@ -1,18 +1,26 @@
 package com.redhat.devtools.intellij.knative.actions.func;
 
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
-import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.knative.actions.DeleteAction;
 import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
+import com.redhat.devtools.intellij.knative.utils.WatchHandler;
+import io.fabric8.kubernetes.client.Watcher;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import static com.redhat.devtools.intellij.knative.Constants.KIND_FUNCTION;
+import static com.redhat.devtools.intellij.knative.Constants.NOTIFICATION_ID;
 
 public class UndeployAction extends DeleteAction {
     public UndeployAction() {
@@ -32,10 +40,44 @@ public class UndeployAction extends DeleteAction {
     }
 
     private void deleteResources(Class type, Map<Class, List<ParentableNode>> resourcesByClass, Kn kncli) throws IOException {
-        List<String> resources = resourcesByClass.get(type).stream().map(x -> x.getName()).collect(Collectors.toList());
+        List<String> resources = resourcesByClass.get(type).stream().map(ParentableNode::getName).collect(Collectors.toList());
         if (type.equals(KnFunctionNode.class)) {
             kncli.deleteFunctions(resources);
+            notifyUndeploy(resources);
+            listenToUndeployComplete(kncli, resources);
         }
+    }
+
+    private void listenToUndeployComplete(Kn kn, List<String> resources) {
+        String id = "Undeploy" + System.currentTimeMillis();
+        AtomicInteger cont = new AtomicInteger();
+        WatchHandler.get(kn).watchResource(id, KIND_FUNCTION, (action, service) -> {
+            if (action == Watcher.Action.DELETED
+                    && resources.stream().anyMatch(res -> res.equalsIgnoreCase(service.getMetadata().getName()))) {
+                int resourcesUndeployed = cont.incrementAndGet();
+                if (resourcesUndeployed >= resources.size()) {
+                    notifyUndeployComplete(resources);
+                    WatchHandler.get(kn).remove(id);
+                }
+            }
+        });
+    }
+
+    private void notifyUndeployComplete(List<String> resources) {
+        String content = (resources.size() > 1 ? resources.size() + " functions" : "Function " + resources.get(0)) + " successfully undeployed.";
+        notifyUndeploy(content);
+    }
+
+    private void notifyUndeploy(List<String> resources) {
+        String content = "Undeploying " + (resources.size() > 1 ? resources.size() + " functions" : "function " + resources.get(0)) + " ...";
+        notifyUndeploy(content);
+    }
+
+    private void notifyUndeploy(String content) {
+        ExecHelper.submit(() -> {
+            Notification notification = new Notification(NOTIFICATION_ID, "Undeploy functions", content, NotificationType.INFORMATION);
+            Notifications.Bus.notify(notification);
+        });
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/UndeployAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/UndeployAction.java
@@ -42,9 +42,10 @@ public class UndeployAction extends DeleteAction {
     private void deleteResources(Class type, Map<Class, List<ParentableNode>> resourcesByClass, Kn kncli) throws IOException {
         List<String> resources = resourcesByClass.get(type).stream().map(ParentableNode::getName).collect(Collectors.toList());
         if (type.equals(KnFunctionNode.class)) {
-            kncli.deleteFunctions(resources);
             notifyUndeploy(resources);
             listenToUndeployComplete(kncli, resources);
+            kncli.deleteFunctions(resources);
+
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/WatchHandler.java
@@ -14,12 +14,16 @@ import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.tree.KnTreeStructure;
 import com.redhat.devtools.intellij.knative.watch.AbstractWatcher;
 import com.redhat.devtools.intellij.knative.watch.FunctionWatcher;
+import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 
@@ -56,6 +60,29 @@ public class WatchHandler {
             return new FunctionWatcher(kn).doWatch(doExecute);
         }
         return null;
+    }
+
+    public void watchResource(String id, String kindToWatch, BiConsumer<Watcher.Action, Service> doExecute) {
+        if (!watches.containsKey(id)) {
+            Watch watch = watchResource(kindToWatch, doExecute);
+            if (watch != null) {
+                watches.put(id, watch);
+            }
+        }
+    }
+
+    private Watch watchResource(String kindToWatch, BiConsumer<Watcher.Action, Service> doExecute) {
+        if (kindToWatch.equalsIgnoreCase(KIND_FUNCTION)) {
+            return new FunctionWatcher(kn).doWatch(doExecute);
+        }
+        return null;
+    }
+
+    public void remove(String id) {
+        if (watches.containsKey(id)) {
+            Watch watch = watches.remove(id);
+            watch.close();
+        }
     }
 
     public void removeAll() {


### PR DESCRIPTION
it resolves #98 

Now it prints two notifications. First when undeploy starts and then when it completes
![image](https://user-images.githubusercontent.com/49404737/153579186-61c60088-fc86-49d4-bc92-2bf178eed714.png)
