### PR TITLE
fix: update regexes to discover clis in PATH (#112)

### DIFF
--- a/src/main/resources/func.json
+++ b/src/main/resources/func.json
@@ -3,8 +3,8 @@
     "func": {
       "version": "0.19.0",
       "versionCmd": "version",
-      "versionExtractRegExp": "Version: (v\\d+[\\.\\d+]*)\\s.*",
-      "versionMatchRegExpr": "0\\..*",
+      "versionExtractRegExp": "v(\\d+[\\.\\d+]*)",
+      "versionMatchRegExpr": "0.19.0",
       "baseDir": "$HOME/.knative",
       "platforms": {
         "win": {

--- a/src/main/resources/kn.json
+++ b/src/main/resources/kn.json
@@ -3,8 +3,8 @@
     "kn": {
       "version": "1.2.0",
       "versionCmd": "version",
-      "versionExtractRegExp": "Version: (v\\d+[\\.\\d+]*)\\s.*",
-      "versionMatchRegExpr": "0\\..*",
+      "versionExtractRegExp": "Version:\\s*v(\\d+[\\.\\d+]*)",
+      "versionMatchRegExpr": "1.2.0",
       "baseDir": "$HOME/.knative",
       "platforms": {
         "win": {


### PR DESCRIPTION
Just found out the detection in PATH didn't work correctly because of wrong regexes rules