### PR TITLE
feat: add invoke action

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions.func;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.intellij.knative.actions.KnAction;
+import com.redhat.devtools.intellij.knative.kn.Function;
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
+import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
+import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import com.redhat.devtools.intellij.knative.ui.invokeFunc.InvokeDialog;
+import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
+import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.tree.TreePath;
+
+import java.io.IOException;
+
+import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.NAME_PREFIX_MISC;
+import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
+
+public class InvokeAction extends KnAction {
+    private static final Logger logger = LoggerFactory.getLogger(InvokeAction.class);
+    private TelemetryMessageBuilder.ActionMessage telemetry;
+
+    public InvokeAction() {
+        super(KnFunctionNode.class);
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn knCli) {
+        telemetry = createTelemetry();
+        ParentableNode node = getElement(selected);
+        String name = node.getName();
+        String namespace = knCli.getNamespace();
+        Function function = ((KnFunctionNode) node).getFunction();
+
+        InvokeModel model = new InvokeModel();
+        model.setNamespace(namespace);
+        model.setPath(function.getLocalPath());
+
+        InvokeDialog dialog = new InvokeDialog("Invoke", getEventProject(anActionEvent), function, model);
+        dialog.show();
+
+        if (dialog.isOK()) {
+            try {
+                knCli.invokeFunc(model);
+                telemetry
+                        .result(anonymizeResource(name, namespace, "Invoked function " + name))
+                        .send();
+            } catch (IOException e) {
+                logger.warn(e.getLocalizedMessage());
+                telemetry
+                        .error(anonymizeResource(name, namespace, e.getLocalizedMessage()))
+                        .send();
+            }
+        } else {
+            telemetry
+                    .result(anonymizeResource(name, namespace, "Invoked function " + name + " operation has been cancelled"))
+                    .send();
+        }
+
+
+    }
+
+    protected TelemetryMessageBuilder.ActionMessage createTelemetry() {
+        return TelemetryService.instance().action(NAME_PREFIX_MISC + "invoke func");
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
@@ -47,6 +47,13 @@ public class InvokeAction extends KnAction {
         String namespace = knCli.getNamespace();
         Function function = ((KnFunctionNode) node).getFunction();
 
+        if (function.getLocalPath().isEmpty()) {
+            telemetry
+                    .result(anonymizeResource(name, namespace, "Function " + name + "is not opened locally"))
+                    .send();
+            return;
+        }
+
         InvokeModel model = new InvokeModel();
         model.setNamespace(namespace);
         model.setPath(function.getLocalPath());
@@ -73,11 +80,17 @@ public class InvokeAction extends KnAction {
                     .result(anonymizeResource(name, namespace, "Invoked function " + name + " operation has been cancelled"))
                     .send();
         }
-
-
     }
 
     protected TelemetryMessageBuilder.ActionMessage createTelemetry() {
         return TelemetryService.instance().action(NAME_PREFIX_MISC + "invoke func");
+    }
+
+    @Override
+    public boolean isVisible(Object selected) {
+        if (selected instanceof KnFunctionNode) {
+            return !((KnFunctionNode) selected).getFunction().getLocalPath().isEmpty();
+        }
+        return false;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
@@ -69,7 +69,7 @@ public class InvokeAction extends KnAction {
                             .result(anonymizeResource(name, namespace, "Invoked function " + name))
                             .send();
                 } catch (IOException e) {
-                    logger.warn(e.getLocalizedMessage());
+                    logger.warn(e.getLocalizedMessage(), e);
                     telemetry
                             .error(anonymizeResource(name, namespace, e.getLocalizedMessage()))
                             .send();

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/InvokeAction.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.intellij.knative.actions.func;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.knative.actions.KnAction;
 import com.redhat.devtools.intellij.knative.kn.Function;
 import com.redhat.devtools.intellij.knative.kn.Kn;
@@ -54,17 +55,19 @@ public class InvokeAction extends KnAction {
         dialog.show();
 
         if (dialog.isOK()) {
-            try {
-                knCli.invokeFunc(model);
-                telemetry
-                        .result(anonymizeResource(name, namespace, "Invoked function " + name))
-                        .send();
-            } catch (IOException e) {
-                logger.warn(e.getLocalizedMessage());
-                telemetry
-                        .error(anonymizeResource(name, namespace, e.getLocalizedMessage()))
-                        .send();
-            }
+            ExecHelper.submit(() -> {
+                try {
+                    knCli.invokeFunc(model);
+                    telemetry
+                            .result(anonymizeResource(name, namespace, "Invoked function " + name))
+                            .send();
+                } catch (IOException e) {
+                    logger.warn(e.getLocalizedMessage());
+                    telemetry
+                            .error(anonymizeResource(name, namespace, e.getLocalizedMessage()))
+                            .send();
+                }
+            });
         } else {
             telemetry
                     .result(anonymizeResource(name, namespace, "Invoked function " + name + " operation has been cancelled"))

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -12,6 +12,7 @@ package com.redhat.devtools.intellij.knative.kn;
 
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
+import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
@@ -218,6 +219,14 @@ public interface Kn {
      */
     void deployFunc(String namespace, String path, String registry, String image) throws IOException;
 
+    /**
+     * Invokes the Function by sending a test request to the currently running
+     * Function instance, either locally or remote
+     *
+     * @param model model representing the function to be invoked
+     * @throws IOException if communication errored
+     */
+    void invokeFunc(InvokeModel model) throws IOException;
 
     /**
      * Run a function locally

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -21,6 +21,7 @@ import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.NetworkUtils;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
+import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import io.fabric8.knative.client.KnativeClient;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -305,6 +306,48 @@ public class KnCli implements Kn {
             args.addAll(Arrays.asList("-n", namespace));
         }
         args.addAll(Arrays.asList("-p", path));
+        return args.toArray(new String[0]);
+    }
+
+    @Override
+    public void invokeFunc(InvokeModel model) throws IOException {
+        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, getInvokeArgs("invoke", model));
+    }
+
+    private String[] getInvokeArgs(String command, InvokeModel model) {
+        List<String> args = new ArrayList<>(Arrays.asList(funcCommand, command));
+        String target = model.getTarget();
+        args.addAll(Arrays.asList("-t", target));
+
+        if (target.equals("local")) {
+            args.addAll(Arrays.asList("-p", model.getPath()));
+        } else {
+            args.addAll(Arrays.asList("-n", model.getNamespace()));
+        }
+
+        if (model.getFile().isEmpty()) {
+            args.addAll(Arrays.asList("--data", model.getData()));
+        } else {
+            args.addAll(Arrays.asList("--file", model.getFile()));
+        }
+        args.addAll((Arrays.asList("--content-type", model.getContentType())));
+
+        if (!model.getID().isEmpty()) {
+            args.addAll(Arrays.asList("--id", model.getID()));
+        }
+
+        if (!model.getFormat().isEmpty()) {
+            args.addAll(Arrays.asList("-f", model.getFormat()));
+        }
+
+        if (!model.getSource().isEmpty()) {
+            args.addAll(Arrays.asList("--source", model.getSource()));
+        }
+
+        if (!model.getType().isEmpty()) {
+            args.addAll(Arrays.asList("--type", model.getType()));
+        }
+
         return args.toArray(new String[0]);
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -311,17 +311,17 @@ public class KnCli implements Kn {
 
     @Override
     public void invokeFunc(InvokeModel model) throws IOException {
-        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, getInvokeArgs("invoke", model));
+        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, getInvokeArgs(model));
     }
 
-    private String[] getInvokeArgs(String command, InvokeModel model) {
-        List<String> args = new ArrayList<>(Arrays.asList(funcCommand, command));
+    private String[] getInvokeArgs(InvokeModel model) {
+        List<String> args = new ArrayList<>(Arrays.asList(funcCommand, "invoke"));
         String target = model.getTarget();
         args.addAll(Arrays.asList("-t", target));
 
-        if (target.equals("local")) {
-            args.addAll(Arrays.asList("-p", model.getPath()));
-        } else {
+        args.addAll(Arrays.asList("-p", model.getPath()));
+
+        if (target.equals("remote")) {
             args.addAll(Arrays.asList("-n", model.getNamespace()));
         }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
@@ -11,6 +11,8 @@
 package com.redhat.devtools.intellij.knative.ui.invokeFunc;
 
 import com.google.common.io.Files;
+import com.intellij.ide.ui.laf.darcula.ui.DarculaTextBorder;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.DialogWrapper;
@@ -37,6 +39,8 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.filechooser.FileSystemView;
@@ -44,6 +48,7 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Insets;
 import java.io.File;
 
 public class InvokeDialog extends DialogWrapper {
@@ -202,14 +207,22 @@ public class InvokeDialog extends DialogWrapper {
         String defaultContentType = System.getenv("FUNC_CONTENT_TYPE") == null ?
                 MimeTypes.TEXT_PLAIN :
                 System.getenv("FUNC_CONTENT_TYPE");
-        txtTypesWithAutoCompletion = new TextFieldWithAutoCompletion<>(project,
+        txtTypesWithAutoCompletion = new TextFieldWithAutoCompletion(project,
                 new TextFieldWithAutoCompletion.StringsCompletionProvider(
                         MimeTypes.getMime().values(),
                         null),
                 true,
                 defaultContentType
-        );
-        //TODO vertically centralize text
+        ) {
+            @Override
+            protected EditorEx createEditor() {
+                EditorEx editor = super.createEditor();
+                CompoundBorder compoundBorder = BorderFactory.createCompoundBorder(new JTextField().getBorder(), JBUI.Borders.empty(7, 7, 3, 7));
+                editor.setBorder(compoundBorder);
+                editor.getContentSize().setSize(200, new JTextField().getHeight());
+                return editor;
+            }
+        };
 
         addComponentToContent(contentPanel, lblContentType, txtTypesWithAutoCompletion, null, 0);
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
@@ -192,12 +192,14 @@ public class InvokeDialog extends DialogWrapper {
     }
 
     private void addInstanceButtonListener(JRadioButton radioButton, String title, JPanel toBeShown, JPanel toBeHidden) {
-        radioButton.addActionListener(e -> {
-            titledBorderInvokeSection.setTitle(title);
-            toBeHidden.setVisible(false);
-            toBeShown.setVisible(true);
-            scrollPane.repaint();
-        });
+        if (radioButton != null) {
+            radioButton.addActionListener(e -> {
+                titledBorderInvokeSection.setTitle(title);
+                toBeHidden.setVisible(false);
+                toBeShown.setVisible(true);
+                scrollPane.repaint();
+            });
+        }
     }
 
     private void addContentTypeField() {

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
@@ -1,0 +1,470 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.invokeFunc;
+
+import com.google.common.io.Files;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.TextFieldWithAutoCompletion;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.ui.JBUI;
+import com.redhat.devtools.intellij.knative.kn.Function;
+import com.redhat.devtools.intellij.knative.utils.MimeTypes;
+import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JTextField;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.border.Border;
+import javax.swing.border.MatteBorder;
+import javax.swing.border.TitledBorder;
+import javax.swing.filechooser.FileSystemView;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.io.File;
+
+public class InvokeDialog extends DialogWrapper {
+    private final Logger logger = LoggerFactory.getLogger(InvokeDialog.class);
+    private JPanel wrapperPanel, contentPanel, panelPath, panelNamespace;
+    private JBScrollPane scrollPane;
+    private Project project;
+    private JTextField txtDataParam, txtIDParam, txtSourceParam, txtTypeParam;
+    private JCheckBox chkSourceParam, chkTypeParam, chkFormatParam;
+    private JRadioButton radioButtonInvokeLocal, radioButtonInvokeRemote;
+    private TextFieldWithAutoCompletion<String> txtTypesWithAutoCompletion;
+    private ComboBox<String> cmbDataType, cmbFormat;
+    private enum INSTANCE {
+        LOCAL,
+        REMOTE,
+        LOCAL_REMOTE
+    }
+    private INSTANCE funcInstance;
+    private final Function function;
+    private InvokeModel model;
+
+    private TitledBorder titledBorderInvokeSection;
+
+    private static final Dimension ROW_DIMENSION = new Dimension(Integer.MAX_VALUE, 40);
+    private static final String AUTOMATICALLY_GENERATED_TEXT = "Automatically generated";
+    private static final String TEXT_OPTION = "Text";
+    private static final String FILE_OPTION = "File";
+    private static final String LOCAL_OPTION = "Local";
+    private static final String REMOTE_OPTION = "Remote";
+
+    public InvokeDialog(String title, Project project, Function function, InvokeModel model) {
+        super(project, true);
+        this.project = project;
+        this.function = function;
+        this.model = model;
+        setFuncInstance(function);
+        setTitle(title);
+        setOKButtonText("Invoke");
+        buildStructure();
+        init();
+    }
+
+    private void setFuncInstance(Function function) {
+        boolean isLocal = !function.getLocalPath().isEmpty();
+        boolean isRemote = function.isPushed();
+
+        if (isLocal && isRemote) {
+            this.funcInstance = INSTANCE.LOCAL_REMOTE;
+        } else if (isLocal) {
+            this.funcInstance = INSTANCE.LOCAL;
+        } else {
+            this.funcInstance = INSTANCE.REMOTE;
+        }
+    }
+
+    private void buildStructure() {
+        wrapperPanel = new JPanel(new BorderLayout());
+
+        if (funcInstance == INSTANCE.LOCAL_REMOTE) {
+            addInstancePicker();
+        }
+
+        contentPanel = new JPanel();
+        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+        fillContentPanel();
+
+        titledBorderInvokeSection = BorderFactory.createTitledBorder(
+                new MatteBorder(1, 0, 0, 0, new JTextField().getBackground()),
+                "Invoke " + (funcInstance == INSTANCE.REMOTE ? REMOTE_OPTION : LOCAL_OPTION) + " Function"
+        );
+
+        scrollPane = new JBScrollPane(contentPanel);
+        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.setBorder(titledBorderInvokeSection);
+
+        wrapperPanel.add(scrollPane, BorderLayout.CENTER);
+    }
+
+    private void fillContentPanel() {
+        addIDField();
+
+        if (funcInstance == INSTANCE.LOCAL
+                || funcInstance == INSTANCE.LOCAL_REMOTE) {
+            panelPath = addPathField();
+        }
+
+        if (funcInstance == INSTANCE.REMOTE
+                || funcInstance == INSTANCE.LOCAL_REMOTE) {
+            panelNamespace = addNamespaceField();
+            panelNamespace.setVisible(funcInstance == INSTANCE.REMOTE);
+        }
+
+        addInstanceButtonListener(radioButtonInvokeLocal,
+                "Invoke Local Function",
+                panelPath,
+                panelNamespace);
+        addInstanceButtonListener(radioButtonInvokeRemote,
+                "Invoke Remote Function",
+                panelNamespace,
+                panelPath);
+
+        addDataField();
+
+        addContentTypeField();
+
+        chkSourceParam = new JCheckBox("<html>Use a custom source value for the request data. (Env: $FUNC_SOURCE)" +
+                " (default \"/boson/fn\")</html>");
+        String defaultSource = System.getenv("FUNC_SOURCE") == null ?
+                "/boson/fn" :
+                System.getenv("FUNC_SOURCE");
+        txtSourceParam = new JTextField(defaultSource);
+        addGroupedComponentsToContent(
+                "Source",
+                chkSourceParam,
+                txtSourceParam
+        );
+
+        chkTypeParam = new JCheckBox("<html>Use a custom type value for the request data. (Env: $FUNC_TYPE) (default \"boson.fn\")</html>");
+        String defaultType = System.getenv("FUNC_TYPE") == null ?
+                "boson.fn" :
+                System.getenv("FUNC_TYPE");
+        txtTypeParam = new JTextField(defaultType);
+        addGroupedComponentsToContent(
+                "Type",
+                chkTypeParam,
+                txtTypeParam
+        );
+
+
+        chkFormatParam = new JCheckBox("<html>Select a specific format of the message to be sent. If not chosen, " +
+                "it will be selected automatically.</html>");
+        cmbFormat = new ComboBox<>();
+        cmbFormat.addItem("http");
+        cmbFormat.addItem("cloudevent");
+
+        addGroupedComponentsToContent(
+                "Format",
+                chkFormatParam,
+                cmbFormat
+        );
+    }
+
+    private void addInstanceButtonListener(JRadioButton radioButton, String title, JPanel toBeShown, JPanel toBeHidden) {
+        radioButton.addActionListener(e -> {
+            titledBorderInvokeSection.setTitle(title);
+            toBeHidden.setVisible(false);
+            toBeShown.setVisible(true);
+            scrollPane.repaint();
+        });
+    }
+
+    private void addContentTypeField() {
+        JLabel lblContentType = createLabel("Content-Type:",
+                "Content Type of the data. (Env: $FUNC_CONTENT_TYPE) (default \"text/plain\")",
+                null);
+        String defaultContentType = System.getenv("FUNC_CONTENT_TYPE") == null ?
+                MimeTypes.TEXT_PLAIN :
+                System.getenv("FUNC_CONTENT_TYPE");
+        txtTypesWithAutoCompletion = new TextFieldWithAutoCompletion<>(project,
+                new TextFieldWithAutoCompletion.StringsCompletionProvider(
+                        MimeTypes.getMime().values(),
+                        null),
+                true,
+                defaultContentType
+        );
+        //TODO vertically centralize text
+
+        addComponentToContent(contentPanel, lblContentType, txtTypesWithAutoCompletion, null, 0);
+    }
+
+    private void addDataField() {
+        JLabel lblDataParam = createLabel("Data:",
+                "Data to send in the request.",
+                null);
+
+        JFileChooser jfc = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory());
+        jfc.setDialogTitle("Choose a file to be used as data.");
+        jfc.setFileSelectionMode(JFileChooser.FILES_ONLY);
+
+        String defaultData = "Hello World";
+        txtDataParam = new JTextField(defaultData);
+        JPanel filePickerPanel = new JPanel(new BorderLayout());
+        filePickerPanel.add(txtDataParam, BorderLayout.CENTER);
+        JButton select = new JButton("...");
+        select.setPreferredSize(new Dimension(50, select.getHeight()));
+        select.setVisible(false);
+        filePickerPanel.add(select, BorderLayout.EAST);
+        select.addActionListener(e -> {
+            int returnValue = jfc.showOpenDialog(null);
+
+            if (returnValue == JFileChooser.APPROVE_OPTION) {
+                File selectedFile = jfc.getSelectedFile();
+                updateData(selectedFile.getAbsolutePath(), selectedFile.getAbsolutePath(), false);
+                String ext = Files.getFileExtension(selectedFile.getName());
+                String contentType = MimeTypes.getMime().getOrDefault("." + ext, MimeTypes.APPLICATION_OCTET_STREAM);
+                txtTypesWithAutoCompletion.setText(contentType);
+            }
+        });
+
+        cmbDataType = new ComboBox<>();
+        cmbDataType.addItem(TEXT_OPTION);
+        cmbDataType.addItem(FILE_OPTION);
+        addComponentToContent(contentPanel, lblDataParam, filePickerPanel, cmbDataType, 0);
+
+        cmbDataType.addItemListener(itemEvent -> {
+            // when combo box value change
+            if (itemEvent.getStateChange() == 1) {
+                String optionSelected = (String) itemEvent.getItem();
+                if (optionSelected.equals(TEXT_OPTION)) {
+                    select.setVisible(false);
+                    updateData(defaultData, "", true);
+                    txtTypesWithAutoCompletion.setText(MimeTypes.TEXT_PLAIN);
+                } else {
+                    select.setVisible(true);
+                    updateData("", "", false);
+                    txtTypesWithAutoCompletion.setText(MimeTypes.APPLICATION_OCTET_STREAM);
+                }
+                contentPanel.repaint();
+            }
+        });
+    }
+
+    private void updateData(String text, String tooltip, boolean finalEnablingState) {
+        if (!txtDataParam.isEnabled()) {
+            txtDataParam.setEnabled(true);
+        }
+        txtDataParam.setText(text);
+        txtDataParam.setToolTipText(tooltip);
+        txtDataParam.setEnabled(finalEnablingState);
+    }
+
+    private JPanel addPathField() {
+        JLabel lblPathParam = createLabel("Path:",
+                "Path to the Function which should have its instance invoked",
+                null);
+
+        JTextField txtPathParam = new JTextField(this.function.getLocalPath());
+        txtPathParam.setEnabled(false);
+        return addComponentToContent(contentPanel, lblPathParam, txtPathParam, null, 0);
+    }
+
+    private JPanel addNamespaceField() {
+        JLabel lblNamespaceParam = createLabel("Namespace:",
+                "The namespace on the cluster",
+                null);
+
+        JTextField txtNamespaceParam = new JTextField(model.getNamespace());
+        txtNamespaceParam.setEnabled(false);
+        JPanel panelNamespace = addComponentToContent(contentPanel, lblNamespaceParam, txtNamespaceParam, null, 0);
+        panelNamespace.setVisible(funcInstance == INSTANCE.REMOTE);
+        return panelNamespace;
+    }
+
+    private void addIDField() {
+        JLabel lblIDParam = createLabel("ID:",
+                "ID for the request data. (Env: $FUNC_ID) (default \"ca8758fc-3bcc-4057-871e-5cea37fa215b\")",
+                null);
+
+        txtIDParam = new JTextField("Automatically generated");
+        txtIDParam.setEnabled(false);
+
+        JCheckBox chkIDCustom = new JCheckBox("<html>Use custom ID</html>");
+        chkIDCustom.setBorder(JBUI.Borders.emptyRight(5));
+        chkIDCustom.addItemListener(itemEvent -> {
+            if (chkIDCustom.isSelected()) {
+                txtIDParam.setEnabled(true);
+                String defaultID = System.getenv("FUNC_ID") == null ?
+                        "ca8758fc-3bcc-4057-871e-5cea37fa215b" :
+                        System.getenv("FUNC_ID");
+                txtIDParam.setText(defaultID);
+            } else {
+                txtIDParam.setText(AUTOMATICALLY_GENERATED_TEXT);
+                txtIDParam.setEnabled(false);
+            }
+        });
+        addComponentToContent(contentPanel, lblIDParam, txtIDParam, chkIDCustom, 15);
+    }
+
+    private void addInstancePicker() {
+        JLabel lblTargetParam = createLabel("Invoke instance:",
+                "Function instance to invoke",
+                JBUI.Borders.empty(0, 3, 0, 15));
+
+        radioButtonInvokeLocal = new JRadioButton(LOCAL_OPTION);
+        radioButtonInvokeLocal.setSelected(true);
+
+        radioButtonInvokeRemote = new JRadioButton(REMOTE_OPTION);
+
+        ButtonGroup group = new ButtonGroup();
+        group.add(radioButtonInvokeLocal);
+        group.add(radioButtonInvokeRemote);
+        JPanel radioButtonsPanel = new JPanel(new FlowLayout(FlowLayout.LEADING));
+        radioButtonsPanel.add(lblTargetParam);
+        radioButtonsPanel.add(radioButtonInvokeLocal);
+        radioButtonsPanel.add(radioButtonInvokeRemote);
+        radioButtonsPanel.setBorder(JBUI.Borders.emptyBottom(20));
+
+        JPanel panel = createFilledPanel(null, radioButtonsPanel, null);
+        wrapperPanel.add(panel, BorderLayout.NORTH);
+    }
+
+    private JLabel createLabel(String text, String tooltip, Border border) {
+        JLabel label = new JLabel(text);
+        if (!tooltip.isEmpty()) {
+            label.setToolTipText(tooltip);
+        }
+        if (border != null) {
+            label.setBorder(border);
+        }
+        return label;
+    }
+
+    private void addGroupedComponentsToContent(String title, JCheckBox chkEnableComponent, JComponent componentCenter) {
+        JPanel panelSource = new JPanel();
+        panelSource.setLayout(new BoxLayout(panelSource, BoxLayout.Y_AXIS));
+        Border compoundBorderMargin = BorderFactory.createCompoundBorder(JBUI.Borders.emptyBottom(8), new MatteBorder(1, 1, 1, 1, new JTextField().getBackground()));
+        Border compoundBorderMargin2 = BorderFactory.createCompoundBorder(compoundBorderMargin, JBUI.Borders.empty(5, 0));
+        TitledBorder titledBorder = BorderFactory.createTitledBorder(compoundBorderMargin2, title);
+        panelSource.setBorder(titledBorder);
+
+        chkEnableComponent.setAlignmentX(Component.LEFT_ALIGNMENT);
+        chkEnableComponent.setBorder(JBUI.Borders.emptyBottom(5));
+        panelSource.add(chkEnableComponent);
+
+        componentCenter.setAlignmentX(Component.LEFT_ALIGNMENT);
+        componentCenter.setMaximumSize(ROW_DIMENSION);
+        componentCenter.setEnabled(false);
+        panelSource.add(componentCenter);
+
+        chkEnableComponent.addItemListener(e -> componentCenter.setEnabled(chkEnableComponent.isSelected()));
+        panelSource.setAlignmentX(Component.LEFT_ALIGNMENT);
+        contentPanel.add(panelSource);
+    }
+
+    private JPanel addComponentToContent(JPanel parent, JComponent componentLeft, JComponent componentCenter, JComponent componentRight, int top) {
+        JPanel panel = createFilledPanel(componentLeft, componentCenter, componentRight);
+        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        panel.setBorder(JBUI.Borders.empty(top, 0, 5, 0));
+        parent.add(panel);
+        return panel;
+    }
+
+    private JPanel createFilledPanel(JComponent componentLeft, JComponent componentCenter, JComponent componentRight) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        if (componentLeft != null) {
+            componentLeft.setBorder(JBUI.Borders.emptyLeft(10));
+            componentLeft.setMinimumSize(new Dimension(120, 40));
+            componentLeft.setPreferredSize(new Dimension(120, 40));
+            componentLeft.setMaximumSize(new Dimension(120, 40));
+            panel.add(componentLeft);
+        }
+        if (componentCenter != null) {
+            componentCenter.setMaximumSize(ROW_DIMENSION);
+            panel.add(componentCenter);
+        }
+        if (componentRight != null) {
+            componentRight.setMaximumSize(new Dimension(150, 40));
+            panel.add(componentRight);
+        }
+        return panel;
+    }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        return txtDataParam;
+    }
+
+    public static void main(String[] args) {
+        InvokeDialog dialog = new InvokeDialog("", null,  null, null);
+        dialog.pack();
+        dialog.show();
+        System.exit(0);
+    }
+
+    @Override
+    protected void doOKAction() {
+        String ID = txtIDParam.getText();
+        if (!ID.equals(AUTOMATICALLY_GENERATED_TEXT)) {
+            model.setID(ID);
+        }
+
+        String dataType = cmbDataType.getSelectedItem().toString();
+        String contentType = txtTypesWithAutoCompletion.getText();
+
+        if (dataType.equals(TEXT_OPTION)) {
+            model.setData(txtDataParam.getText());
+            model.setContentType(contentType.isEmpty() ? MimeTypes.TEXT_PLAIN : contentType);
+        } else {
+            model.setFile(txtDataParam.getText());
+            model.setContentType(contentType.isEmpty() ? MimeTypes.APPLICATION_OCTET_STREAM : contentType);
+        }
+
+        if ((funcInstance.equals(INSTANCE.LOCAL_REMOTE) && radioButtonInvokeLocal.isSelected())
+                || funcInstance.equals(INSTANCE.LOCAL)) {
+            model.setTarget("local");
+        } else {
+            model.setTarget("remote");
+        }
+
+        if (chkSourceParam.isSelected()) {
+            model.setSource(txtSourceParam.getText());
+        }
+
+        if (chkTypeParam.isSelected()) {
+            model.setType(txtTypeParam.getText());
+        }
+
+        if (chkFormatParam.isSelected()) {
+            model.setFormat(cmbFormat.getSelectedItem().toString());
+        }
+
+        super.doOKAction();
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        final JPanel panel = new JPanel(new BorderLayout());
+        panel.setMinimumSize(new Dimension(500, 400));
+        panel.add(wrapperPanel, BorderLayout.CENTER);
+        return panel;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/MimeTypes.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/MimeTypes.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MimeTypes {
+
+    public final static String TEXT_PLAIN = "text/plain";
+    public final static String APPLICATION_OCTET_STREAM = "application/octet-stream";
+    private final static Map<String, String> mime;
+    static {
+        mime = new HashMap<>();
+        mime.put(".aac", "udio/aac");
+        mime.put(".abw", "application/x-abiword");
+        mime.put(".arc", "application/x-freearc");
+        mime.put(".avif", "image/avif");
+        mime.put(".avi", "video/x-msvideo");
+        mime.put(".azw", "application/vnd.amazon.ebook");
+        mime.put(".bin", "application/octet-stream");
+        mime.put(".bmp", "image/bmp");
+        mime.put(".bz", "application/x-bzip");
+        mime.put(".bz2", "application/x-bzip2");
+        mime.put(".cda", "application/x-cdf");
+        mime.put(".csh", "application/x-csh");
+        mime.put(".css", "text/css");
+        mime.put(".csv", "text/csv");
+        mime.put(".doc", "application/msword");
+        mime.put(".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        mime.put(".eot", "application/vnd.ms-fontobject");
+        mime.put(".epub", "application/epub+zip");
+        mime.put(".gz", "application/gzip");
+        mime.put(".gif", "image/gif");
+        mime.put(".htm", "text/html");
+        mime.put(".html", "text/html");
+        mime.put(".ico", "image/vnd.microsoft.icon");
+        mime.put(".ics", "text/calendar");
+        mime.put(".jpg", "image/jpeg");
+        mime.put(".jpeg", "image/jpeg");
+        mime.put(".js", "text/javascript");
+        mime.put(".json", "application/json");
+        mime.put(".jsonld", "application/ld+json");
+        mime.put(".midi", "audio/midi");
+        mime.put(".mp3", "audio/mpeg");
+        mime.put(".mp4", "video/mp4");
+        mime.put(".mpeg", "video/mpeg");
+        mime.put(".odp", "application/vnd.oasis.opendocument.presentation");
+        mime.put(".ods", "application/vnd.oasis.opendocument.spreadsheet");
+        mime.put(".odt", "application/vnd.oasis.opendocument.text");
+        mime.put(".oga", "audio/ogg");
+        mime.put(".ogv", "video/ogg");
+        mime.put(".ogx", "application/ogg");
+        mime.put(".opus", "audio/opus");
+        mime.put(".png", "image/png");
+        mime.put(".pdf", "application/pdf");
+        mime.put(".php", "application/x-httpd-php");
+        mime.put(".ppt", "application/vnd.ms-powerpoint");
+        mime.put(".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+        mime.put(".rar", "application/vnd.rar");
+        mime.put(".rtf", "application/rtf");
+        mime.put(".sh", "application/x-sh");
+        mime.put(".svg", "image/svg+xml");
+        mime.put(".tar", "application/x-tar");
+        mime.put(".tiff", "image/tiff");
+        mime.put(".txt", "text/plain");
+        mime.put(".wav", "audio/wav");
+        mime.put(".weba", "audio/webm");
+        mime.put(".webm", "video/webm");
+        mime.put(".webp", "image/webp");
+        mime.put(".xhtml", "application/xhtml+xml");
+        mime.put(".xls", "application/vnd.ms-excel");
+        mime.put(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        mime.put(".xml", "application/xml");
+        mime.put(".zip", "application/zip");
+        mime.put(".3gp", "video/3gpp");
+        mime.put(".3g2", "video/3gpp2");
+        mime.put(".7z", "application/x-7z-compressed");
+    }
+
+    public static Map<String, String> getMime() {
+        return mime;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/model/InvokeModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/model/InvokeModel.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils.model;
+
+public class InvokeModel {
+    private String ID, path, namespace, data, contentType, file, source, type, format, target;
+
+    public InvokeModel() {
+        this("", "", "", "", "", "", "", "", "", "");
+    }
+
+    public InvokeModel(String ID, String path, String namespace, String data, String contentType, String file,
+                       String source, String type, String format, String target) {
+        this.ID = ID;
+        this.path = path;
+        this.namespace = namespace;
+        this.data = data;
+        this.contentType = contentType;
+        this.file = file;
+        this.source = source;
+        this.type = type;
+        this.format = format;
+        this.target = target;
+    }
+
+    public String getID() {
+        return ID;
+    }
+
+    public void setID(String ID) {
+        this.ID = ID;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,6 +68,9 @@
             <action id="com.redhat.devtools.intellij.knative.actions.func.DeployAction"
                     class="com.redhat.devtools.intellij.knative.actions.func.DeployAction"
                     text="Deploy"/>
+            <action id="com.redhat.devtools.intellij.knative.actions.func.InvokeAction"
+                    class="com.redhat.devtools.intellij.knative.actions.func.InvokeAction"
+                    text="Invoke"/>
             <group id="com.redhat.devtools.intellij.knative.actions.func.AddConfigAction"
                    text="Add Config"
                    popup="true">

--- a/src/main/resources/func.json
+++ b/src/main/resources/func.json
@@ -1,26 +1,26 @@
 {
   "tools": {
     "func": {
-      "version": "0.19.0",
+      "version": "0.22.0",
       "versionCmd": "version",
       "versionExtractRegExp": "v(\\d+[\\.\\d+]*)",
-      "versionMatchRegExpr": "0.19.0",
+      "versionMatchRegExpr": "0.22.0",
       "baseDir": "$HOME/.knative",
       "platforms": {
         "win": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.19.0/func_windows_amd64.exe.gz",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.22.0/func_windows_amd64.exe",
           "cmdFileName": "func_windows_amd64.exe",
-          "dlFileName": "func_windows_amd64.exe.gz"
+          "dlFileName": "func_windows_amd64.exe"
         },
         "osx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.19.0/func_darwin_amd64.gz",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.22.0/func_darwin_amd64",
           "cmdFileName": "func_darwin_amd64",
-          "dlFileName": "func_darwin_amd64.gz"
+          "dlFileName": "func_darwin_amd64"
         },
         "lnx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.19.0/func_linux_amd64.gz",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.22.0/func_linux_amd64",
           "cmdFileName": "func_linux_amd64",
-          "dlFileName": "func_linux_amd64.gz"
+          "dlFileName": "func_linux_amd64"
         }
       }
     }


### PR DESCRIPTION
it resolves #96 

An example below. Few things to be mentioned.
1) If you open an only local/only remote function you won't see the instances options at the top.
2) The content-type textboxes is auto-filled based on the file picked by the user (e.g a file .jpg will have the image/jpeg mime type automatically selected)
3) The func cli claims to get values from env variables for their args. I only check those related to source/format/type/content-type/id. I skipped the others as i don't think it makes sense from an IDE perspective :thinking: 

![invoke_func](https://user-images.githubusercontent.com/49404737/157402091-740845cd-a747-48d3-8980-19620b295c15.gif)

![invoke_autocomplete](https://user-images.githubusercontent.com/49404737/157404301-cab604f2-1103-4b92-ac97-c48879ee489e.gif)

cc @sudhirverma @mohitsuman 

