### PR TITLE
feat: add actions to manage Function repos (#97)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RepositoryAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RepositoryAction.java
@@ -11,15 +11,21 @@
 package com.redhat.devtools.intellij.knative.actions.func;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.ui.Messages;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.knative.actions.KnAction;
 import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
+import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
 import com.redhat.devtools.intellij.knative.tree.KnRootNode;
+import com.redhat.devtools.intellij.knative.tree.ParentableNode;
 import com.redhat.devtools.intellij.knative.ui.repository.Repository;
 import com.redhat.devtools.intellij.knative.ui.repository.RepositoryDialog;
+import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,17 +36,20 @@ import java.util.List;
 
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.NAME_PREFIX_MISC;
 
-public class RepositoryAction extends KnAction {
+public class RepositoryAction extends DumbAwareAction {
     private static final Logger logger = LoggerFactory.getLogger(RepositoryAction.class);
 
     private TelemetryMessageBuilder.ActionMessage telemetry;
 
-    public RepositoryAction() {
-        super(KnRootNode.class);
-    }
+    public RepositoryAction() { }
 
     @Override
-    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn knCli) {
+    public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+        Kn knCli = TreeHelper.getKn(anActionEvent.getProject());
+        if (knCli == null) {
+            return;
+        }
+
         telemetry = TelemetryService.instance().action(NAME_PREFIX_MISC + "repo func");
         ExecHelper.submit(() -> {
             List<Repository> repositories = new ArrayList<>();

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RepositoryAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RepositoryAction.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions.func;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.ui.CollectionListModel;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.UIHelper;
+import com.redhat.devtools.intellij.knative.actions.KnAction;
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
+import com.redhat.devtools.intellij.knative.tree.KnRootNode;
+import com.redhat.devtools.intellij.knative.ui.repository.Repository;
+import com.redhat.devtools.intellij.knative.ui.repository.RepositoryDialog;
+import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.tree.TreePath;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.redhat.devtools.intellij.knative.Constants.NOTIFICATION_ID;
+import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.NAME_PREFIX_MISC;
+import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
+
+public class RepositoryAction extends KnAction {
+    private static final Logger logger = LoggerFactory.getLogger(RepositoryAction.class);
+
+    private TelemetryMessageBuilder.ActionMessage telemetry;
+
+    public RepositoryAction() {
+        super(KnRootNode.class);
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn knCli) {
+        telemetry = TelemetryService.instance().action(NAME_PREFIX_MISC + "repo func");
+        ExecHelper.submit(() -> {
+            List<Repository> repositories = new ArrayList<>();
+            try {
+                repositories.addAll(knCli.getRepos());
+            } catch (IOException e) {
+                logger.warn(e.getLocalizedMessage(), e);
+                telemetry
+                        .error(e.getLocalizedMessage())
+                        .send();
+            }
+            RepositoryDialog dialog = UIHelper.executeInUI(() -> {
+                RepositoryDialog repositoryDialog = new RepositoryDialog(anActionEvent.getProject(), repositories);
+                repositoryDialog.show();
+                return repositoryDialog;
+            });
+
+            if (dialog.isOK()) {
+                CollectionListModel<Repository> model = dialog.getModel();
+                updateRepos(knCli, repositories, model.getItems());
+            }
+        });
+    }
+
+    private void updateRepos(Kn kncli, List<Repository> originalRepos, List<Repository> updatedRepos) {
+        List<Repository> toBeDeleted = findReposOnlyBelongToFirstCollection(updatedRepos, originalRepos);
+        List<Repository> toBeCreated = findReposOnlyBelongToFirstCollection(originalRepos, updatedRepos);
+
+        for (Repository repo: toBeDeleted) {
+            doRemoveAction(kncli, repo);
+        }
+
+        for (Repository newRepo: toBeCreated) {
+            doAddAction(kncli, newRepo);
+        }
+    }
+
+    private void doAddAction(Kn kncli, Repository repository) {
+        try {
+            kncli.addRepo(repository);
+            sendAddNotification(repository);
+        } catch (IOException e) {
+            sendErrorNotification(repository, e);
+        }
+    }
+
+    private void doRemoveAction(Kn kncli, Repository repository) {
+        try {
+            kncli.removeRepo(repository);
+            sendRemoveNotification(repository);
+        } catch (IOException e) {
+            sendErrorNotification(repository, e);
+        }
+    }
+
+    private void sendErrorNotification(Repository repository, IOException e) {
+        Notification notification = new Notification(NOTIFICATION_ID,
+                "Error",
+                e.getLocalizedMessage(),
+                NotificationType.ERROR);
+        Notifications.Bus.notify(notification);
+        logger.warn(e.getLocalizedMessage(), e);
+        telemetry
+                .error(anonymizeResource(repository.getName(), "", e.getLocalizedMessage()))
+                .send();
+    }
+
+    private void sendAddNotification(Repository repository) {
+        sendSuccessfulNotification("Added Successfully", repository.getName() + " has been saved!", repository.getName());
+    }
+
+    private void sendRemoveNotification(Repository repository) {
+        sendSuccessfulNotification("Removed Successfully", repository.getName() + " has been removed!", repository.getName());
+    }
+
+    private void sendSuccessfulNotification(String title, String content, String repoName) {
+        Notification notification = new Notification(NOTIFICATION_ID, title, content, NotificationType.INFORMATION);
+        Notifications.Bus.notify(notification);
+        telemetry
+                .result(anonymizeResource(repoName, "", content))
+                .send();
+    }
+
+    private List<Repository> findReposOnlyBelongToFirstCollection(List<Repository> firstCollection, List<Repository> secondCollection) {
+        List<Repository> toBeCreated = new ArrayList<>();
+        for (Repository repo: secondCollection) {
+            boolean isNew = firstCollection.stream().noneMatch(oRepo ->
+                    oRepo.getUrl().equalsIgnoreCase(repo.getUrl())
+                        && oRepo.getName().equalsIgnoreCase(repo.getName()));
+            if (isNew) {
+                toBeCreated.add(repo);
+            }
+        }
+        return toBeCreated;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RepositoryAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RepositoryAction.java
@@ -10,11 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.actions.func;
 
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.ui.CollectionListModel;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.knative.actions.KnAction;
@@ -32,9 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.redhat.devtools.intellij.knative.Constants.NOTIFICATION_ID;
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.NAME_PREFIX_MISC;
-import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
 
 public class RepositoryAction extends KnAction {
     private static final Logger logger = LoggerFactory.getLogger(RepositoryAction.class);
@@ -58,88 +52,14 @@ public class RepositoryAction extends KnAction {
                         .error(e.getLocalizedMessage())
                         .send();
             }
-            RepositoryDialog dialog = UIHelper.executeInUI(() -> {
-                RepositoryDialog repositoryDialog = new RepositoryDialog(anActionEvent.getProject(), repositories);
+            UIHelper.executeInUI(() -> {
+                RepositoryDialog repositoryDialog = new RepositoryDialog(
+                        anActionEvent.getProject(),
+                        knCli,
+                        repositories,
+                        telemetry);
                 repositoryDialog.show();
-                return repositoryDialog;
             });
-
-            if (dialog.isOK()) {
-                CollectionListModel<Repository> model = dialog.getModel();
-                updateRepos(knCli, repositories, model.getItems());
-            }
         });
-    }
-
-    private void updateRepos(Kn kncli, List<Repository> originalRepos, List<Repository> updatedRepos) {
-        List<Repository> toBeDeleted = findReposOnlyBelongToFirstCollection(updatedRepos, originalRepos);
-        List<Repository> toBeCreated = findReposOnlyBelongToFirstCollection(originalRepos, updatedRepos);
-
-        for (Repository repo: toBeDeleted) {
-            doRemoveAction(kncli, repo);
-        }
-
-        for (Repository newRepo: toBeCreated) {
-            doAddAction(kncli, newRepo);
-        }
-    }
-
-    private void doAddAction(Kn kncli, Repository repository) {
-        try {
-            kncli.addRepo(repository);
-            sendAddNotification(repository);
-        } catch (IOException e) {
-            sendErrorNotification(repository, e);
-        }
-    }
-
-    private void doRemoveAction(Kn kncli, Repository repository) {
-        try {
-            kncli.removeRepo(repository);
-            sendRemoveNotification(repository);
-        } catch (IOException e) {
-            sendErrorNotification(repository, e);
-        }
-    }
-
-    private void sendErrorNotification(Repository repository, IOException e) {
-        Notification notification = new Notification(NOTIFICATION_ID,
-                "Error",
-                e.getLocalizedMessage(),
-                NotificationType.ERROR);
-        Notifications.Bus.notify(notification);
-        logger.warn(e.getLocalizedMessage(), e);
-        telemetry
-                .error(anonymizeResource(repository.getName(), "", e.getLocalizedMessage()))
-                .send();
-    }
-
-    private void sendAddNotification(Repository repository) {
-        sendSuccessfulNotification("Added Successfully", repository.getName() + " has been saved!", repository.getName());
-    }
-
-    private void sendRemoveNotification(Repository repository) {
-        sendSuccessfulNotification("Removed Successfully", repository.getName() + " has been removed!", repository.getName());
-    }
-
-    private void sendSuccessfulNotification(String title, String content, String repoName) {
-        Notification notification = new Notification(NOTIFICATION_ID, title, content, NotificationType.INFORMATION);
-        Notifications.Bus.notify(notification);
-        telemetry
-                .result(anonymizeResource(repoName, "", content))
-                .send();
-    }
-
-    private List<Repository> findReposOnlyBelongToFirstCollection(List<Repository> firstCollection, List<Repository> secondCollection) {
-        List<Repository> toBeCreated = new ArrayList<>();
-        for (Repository repo: secondCollection) {
-            boolean isNew = firstCollection.stream().noneMatch(oRepo ->
-                    oRepo.getUrl().equalsIgnoreCase(repo.getUrl())
-                        && oRepo.getName().equalsIgnoreCase(repo.getName()));
-            if (isNew) {
-                toBeCreated.add(repo);
-            }
-        }
-        return toBeCreated;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -261,6 +261,14 @@ public interface Kn {
     void addRepo(Repository repository) throws IOException;
 
     /**
+     * Rename a repo
+     *
+     * @param repository repository to rename remotely
+     * @throws IOException if communication errored
+     */
+    void renameRepo(Repository repository) throws IOException;
+
+    /**
      * Remove a Function repository
      *
      * @param repository repository to be removed

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -309,6 +309,14 @@ public interface Kn {
     void removeVolume(String path) throws IOException;
 
     /**
+     * List all templates availabl
+     *
+     * @return list of all templates available
+     * @throws IOException if communication errored
+     */
+    Map<String, List<String>> getFuncTemplates() throws IOException;
+
+    /**
      * Set a watch on Service resource with label
      *
      * @param key     key label

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.func.FuncActionPipelineManager;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
+import com.redhat.devtools.intellij.knative.ui.repository.Repository;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
@@ -250,6 +251,30 @@ public interface Kn {
     void runFunc(String path, ConsoleView terminalExecutionConsole,
                  java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
                  ProcessListener processListener) throws IOException;
+
+    /**
+     * Create a new repository to retrieve new Function templates
+     *
+     * @param repository repository to be added
+     * @throws IOException if communication errored
+     */
+    void addRepo(Repository repository) throws IOException;
+
+    /**
+     * Remove a Function repository
+     *
+     * @param repository repository to be removed
+     * @throws IOException if communication errored
+     */
+    void removeRepo(Repository repository) throws IOException;
+
+    /**
+     * Return a list of Function repositories
+     *
+     * @return a list of Function repositories
+     * @throws IOException if communication errored
+     */
+    List<Repository> getRepos() throws IOException;
 
     /**
      * Add environment variable to the function configuration

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -60,6 +60,7 @@ import static com.redhat.devtools.intellij.knative.Constants.KNATIVE_TOOL_WINDOW
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.IS_OPENSHIFT;
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.KUBERNETES_VERSION;
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.OPENSHIFT_VERSION;
+import static com.redhat.devtools.intellij.knative.ui.repository.RepositoryUtils.NATIVE_NAME;
 
 
 public class KnCli implements Kn {
@@ -307,7 +308,7 @@ public class KnCli implements Kn {
 
     @Override
     public void createFunc(CreateFuncModel model) throws IOException {
-        ExecHelper.execute(funcCommand, envVars, "create", model.getPath(), "-l", model.getRuntime(), "-t", model.getTemplate());
+        ExecHelper.execute(funcCommand, envVars, "create", model.getPath(), "-l", model.getRuntime(), "-t", model.getTemplate(), "-n", getNamespace());
     }
 
     @Override
@@ -401,12 +402,17 @@ public class KnCli implements Kn {
 
     @Override
     public void addRepo(Repository repository) throws IOException {
-        ExecHelper.execute(funcCommand, envVars, "repository", "add", repository.getName(), repository.getUrl());
+        ExecHelper.execute(funcCommand, envVars, "repository", "add", repository.getName(), repository.getUrl(), "-n", getNamespace());
+    }
+
+    @Override
+    public void renameRepo(Repository repository) throws IOException {
+        ExecHelper.execute(funcCommand, envVars, "repository", "rename", repository.getAttribute(NATIVE_NAME), repository.getName(), "-n", getNamespace());
     }
 
     @Override
     public void removeRepo(Repository repository) throws IOException {
-        ExecHelper.execute(funcCommand, envVars, "repository", "remove", repository.getName());
+        ExecHelper.execute(funcCommand, envVars, "repository", "remove", repository.getName(), "-n", getNamespace());
     }
 
     @Override
@@ -447,7 +453,7 @@ public class KnCli implements Kn {
 
     @Override
     public Map<String, List<String>> getFuncTemplates() throws IOException {
-        String list = ExecHelper.execute(funcCommand, envVars, "templates", "--json");
+        String list = ExecHelper.execute(funcCommand, envVars, "templates", "--json", "-n", getNamespace());
         return JSON_MAPPER.readValue(list, Map.class);
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -28,6 +28,7 @@ import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.func.FuncActionPipelineManager;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
+import com.redhat.devtools.intellij.knative.ui.repository.Repository;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import io.fabric8.knative.client.KnativeClient;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -52,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static com.redhat.devtools.intellij.knative.Constants.KNATIVE_TOOL_WINDOW_ID;
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.IS_OPENSHIFT;
@@ -394,6 +396,25 @@ public class KnCli implements Kn {
                         java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
                         ProcessListener processListener) throws IOException {
         ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processHandlerFunction, processListener, funcCommand, "run", "-p", path, "-b=false");
+    }
+
+    @Override
+    public void addRepo(Repository repository) throws IOException {
+        ExecHelper.execute(funcCommand, envVars, "repository", "add", repository.getName(), repository.getUrl());
+    }
+
+    @Override
+    public void removeRepo(Repository repository) throws IOException {
+        ExecHelper.execute(funcCommand, envVars, "repository", "remove", repository.getName());
+    }
+
+    @Override
+    public List<Repository> getRepos() throws IOException {
+        String list = ExecHelper.execute(funcCommand, envVars, "repository", "list");
+        return Arrays.stream(list.split("\n"))
+                .filter(name -> !name.trim().equalsIgnoreCase("default") && !name.trim().isEmpty())
+                .map(Repository::new)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/UIConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/UIConstants.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui;
+
+import com.intellij.ui.JBColor;
+
+import javax.swing.border.Border;
+import javax.swing.border.MatteBorder;
+import java.awt.Color;
+
+public class UIConstants {
+    public static final Color RED = new JBColor(new Color(229, 77, 4), new Color(229, 77, 4));
+
+    public static final Border RED_BORDER_SHOW_ERROR = new MatteBorder(1, 1, 1, 1, RED);
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/createFunc/FunctionBuilderUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/createFunc/FunctionBuilderUtils.java
@@ -49,7 +49,7 @@ public class FunctionBuilderUtils {
 
     }
 
-    private static Kn getKn() {
+    public static Kn getKn() {
         Project[] projects = ProjectManager.getInstance().getOpenProjects();
         for (Project project: projects) {
             Kn kn = TreeHelper.getKn(project);

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/CreateRepositoryDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/CreateRepositoryDialog.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.repository;
+
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.components.JBScrollPane;
+import com.redhat.devtools.intellij.knative.ui.DeleteDialog;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Box;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.Arrays;
+
+public class CreateRepositoryDialog extends DialogWrapper {
+    private JPanel myContentPanel;
+    private JTextField txtName, txtUrl;
+    private Repository repository;
+
+    public CreateRepositoryDialog(Repository repository) {
+        super(null, null, false, DialogWrapper.IdeModalityType.IDE);
+        this.repository = repository;
+
+        setTitle("New Repository");
+        setOKButtonText("Create");
+        fillContainer();
+        init();
+    }
+
+    public static void main(String[] args) {
+        DeleteDialog dialog = new DeleteDialog(null, "", "", "");
+        dialog.pack();
+        dialog.show();
+        System.exit(0);
+    }
+
+    @Override
+    protected void doOKAction() {
+        repository.setName(txtName.getText());
+        repository.setUrl(txtUrl.getText());
+        super.doOKAction();
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        final JPanel panel = new JPanel(new BorderLayout());
+        panel.add(myContentPanel, BorderLayout.CENTER);
+        return panel;
+    }
+
+    private void fillContainer() {
+        myContentPanel = new JPanel(new BorderLayout());
+        txtName = new JTextField();
+        txtUrl = new JTextField();
+        myContentPanel.add(RepositoryUtils.createPanelRepository(txtName, txtUrl), BorderLayout.CENTER);
+    }
+}
+

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/Repository.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/Repository.java
@@ -1,0 +1,46 @@
+package com.redhat.devtools.intellij.knative.ui.repository;
+
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+public class Repository {
+
+    private String name, url;
+
+    public Repository() {
+
+    }
+
+    public Repository(String name) {
+        this.name = name;
+        this.url = "";
+    }
+
+    public Repository(String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/Repository.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/Repository.java
@@ -1,7 +1,3 @@
-package com.redhat.devtools.intellij.knative.ui.repository;
-
-import java.util.Objects;
-
 /*******************************************************************************
  * Copyright (c) 2022 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
@@ -12,22 +8,32 @@ import java.util.Objects;
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.redhat.devtools.intellij.knative.ui.repository.RepositoryUtils.NATIVE_NAME;
+
 public class Repository {
 
     private String name, url;
+    private Map<String, String> attributes;
 
     public Repository() {
-
+        this("", "");
     }
 
     public Repository(String name) {
-        this.name = name;
-        this.url = "";
+        this(name, "");
     }
 
     public Repository(String name, String url) {
         this.name = name;
         this.url = url;
+        this.attributes = new HashMap<>();
+        this.attributes.put(NATIVE_NAME, name);
     }
 
     public String getName() {
@@ -46,6 +52,14 @@ public class Repository {
         this.url = url;
     }
 
+    public void setAttribute(String key, String value) {
+        attributes.put(key, value);
+    }
+
+    public String getAttribute(String key) {
+        return attributes.get(key);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,5 +71,9 @@ public class Repository {
     @Override
     public int hashCode() {
         return Objects.hash(name, url);
+    }
+
+    public Repository clone() {
+        return new Repository(getName(), getUrl());
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/Repository.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/Repository.java
@@ -1,5 +1,7 @@
 package com.redhat.devtools.intellij.knative.ui.repository;
 
+import java.util.Objects;
+
 /*******************************************************************************
  * Copyright (c) 2022 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
@@ -42,5 +44,18 @@ public class Repository {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Repository that = (Repository) o;
+        return Objects.equals(name, that.name) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, url);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
@@ -219,6 +219,7 @@ public class RepositoryDialog extends DialogWrapper {
                 if (validName) {
                     repo.setName(name);
                     itemEditor.clone(repo, true);
+                    editor.invalidate();
                 }
                 setError(!validName);
             }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
@@ -10,35 +10,44 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.ui.repository;
 
-import com.intellij.openapi.keymap.impl.ui.KeymapListener;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.ui.CollectionListModel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.ListItemEditor;
-import com.intellij.util.ui.ListModelEditor;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
-import java.util.Arrays;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static com.redhat.devtools.intellij.knative.Constants.NOTIFICATION_ID;
+import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
 
 public class RepositoryDialog extends DialogWrapper {
 
+    private static final Logger logger = LoggerFactory.getLogger(RepositoryDialog.class);
     public static final String EMPTY = "empty";
     public static final String PANEL = "panel";
+    public final List<RepositoryUtils.RepositoryChange> changes = new ArrayList<>();
 
     private final ListItemEditor<Repository> itemEditor = new ListItemEditor<Repository>() {
 
@@ -50,7 +59,12 @@ public class RepositoryDialog extends DialogWrapper {
 
         @Override
         public Repository clone(@NotNull Repository item, boolean forInPlaceEditing) {
-            return new Repository(item.getName(), item.getUrl());
+            if (pendingChanges.stream().noneMatch(repo -> repo.getName().equalsIgnoreCase(item.getName()))){
+                updateChanges(item, RepositoryUtils.Operation.CREATE);
+                pendingChanges.add(item);
+                return item;
+            }
+            return null;
         }
 
         @Override
@@ -66,7 +80,21 @@ public class RepositoryDialog extends DialogWrapper {
 
         @Override
         public boolean isRemovable(@NotNull Repository item) {
+            updateChanges(item, RepositoryUtils.Operation.DELETE);
+            pendingChanges.remove(item);
             return true;
+        }
+
+        private void updateChanges(Repository item, RepositoryUtils.Operation operation) {
+            Optional<RepositoryUtils.RepositoryChange> pendingChange = changes.stream()
+                    .filter(repo -> repo.getRepository().equals(item))
+                    .findFirst();
+            if (pendingChange.isPresent()) {
+                changes.remove(pendingChange.get());
+            } else {
+                changes.add(new RepositoryUtils.RepositoryChange(item, operation));
+            }
+            updateApplyButtonEnabling();
         }
     };
 
@@ -74,14 +102,20 @@ public class RepositoryDialog extends DialogWrapper {
 
     private JComponent component;
     private JPanel itemPanelWrapper;
-    private List<Repository> repositories;
+    private List<Repository> repositories, pendingChanges;
     private JTextField txtName, txtUrl;
+    private Kn kncli;
+    private TelemetryMessageBuilder.ActionMessage telemetry;
 
-    public RepositoryDialog(@Nullable Project project, List<Repository> repositories) {
+    public RepositoryDialog(@Nullable Project project, Kn kncli, List<Repository> repositories, TelemetryMessageBuilder.ActionMessage telemetry) {
         super(project, false);
         this.repositories = repositories;
+        this.pendingChanges = repositories;
+        this.kncli = kncli;
+        this.telemetry = telemetry;
         setTitle("Repository");
         setOKButtonText("Apply");
+        updateApplyButtonEnabling();
         buildStructure(repositories);
         init();
     }
@@ -112,7 +146,9 @@ public class RepositoryDialog extends DialogWrapper {
 
         itemPanelWrapper.add(descLabel, EMPTY);
         txtName = new JTextField();
+        txtName.setEditable(false);
         txtUrl = new JTextField();
+        txtUrl.setEditable(false);
         itemPanelWrapper.add(RepositoryUtils.createPanelRepository(txtName, txtUrl), PANEL);
 
 
@@ -133,5 +169,75 @@ public class RepositoryDialog extends DialogWrapper {
 
     public CollectionListModel<Repository> getModel() {
         return editor.getModel();
+    }
+
+    @Override
+    protected void doOKAction() {
+        List<RepositoryUtils.RepositoryChange> finalChanges = copyChanges();
+        changes.clear();
+        updateApplyButtonEnabling();
+        ExecHelper.submit(() -> {
+            for (RepositoryUtils.RepositoryChange pendingChange : finalChanges) {
+                try {
+                    if (pendingChange.getOperation().equals(RepositoryUtils.Operation.CREATE)) {
+                        doAddRepository(pendingChange.getRepository());
+                    } else if (pendingChange.getOperation().equals(RepositoryUtils.Operation.DELETE)) {
+                        doRemoveRepository(pendingChange.getRepository());
+                    }
+                } catch (IOException e) {
+                    sendErrorNotification(pendingChange.getRepository(), e);
+                }
+            }
+        });
+    }
+
+    private void updateApplyButtonEnabling() {
+        setOKActionEnabled(changes.size() > 0);
+    }
+
+    private List<RepositoryUtils.RepositoryChange> copyChanges() {
+        List<RepositoryUtils.RepositoryChange> finalChanges = new ArrayList<>();
+        for (RepositoryUtils.RepositoryChange change: changes) {
+            finalChanges.add(change.clone());
+        }
+        return finalChanges;
+    }
+
+    private void doAddRepository(Repository repository) throws IOException {
+        kncli.addRepo(repository);
+        sendAddNotification(repository);
+    }
+
+    private void doRemoveRepository(Repository repository) throws IOException {
+        kncli.removeRepo(repository);
+        sendRemoveNotification(repository);
+    }
+
+    private void sendErrorNotification(Repository repository, IOException e) {
+        Notification notification = new Notification(NOTIFICATION_ID,
+                "Error",
+                e.getLocalizedMessage(),
+                NotificationType.ERROR);
+        Notifications.Bus.notify(notification);
+        logger.warn(e.getLocalizedMessage(), e);
+        telemetry
+                .error(anonymizeResource(repository.getName(), "", e.getLocalizedMessage()))
+                .send();
+    }
+
+    private void sendAddNotification(Repository repository) {
+        sendSuccessfulNotification("Added Successfully", repository.getName() + " has been saved!", repository.getName());
+    }
+
+    private void sendRemoveNotification(Repository repository) {
+        sendSuccessfulNotification("Removed Successfully", repository.getName() + " has been removed!", repository.getName());
+    }
+
+    private void sendSuccessfulNotification(String title, String content, String repoName) {
+        Notification notification = new Notification(NOTIFICATION_ID, title, content, NotificationType.INFORMATION);
+        Notifications.Bus.notify(notification);
+        telemetry
+                .result(anonymizeResource(repoName, "", content))
+                .send();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.ui.CollectionListModel;
+import com.intellij.ui.DocumentAdapter;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.ListItemEditor;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
@@ -31,6 +32,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
@@ -38,8 +40,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.redhat.devtools.intellij.knative.Constants.NOTIFICATION_ID;
+import static com.redhat.devtools.intellij.knative.ui.UIConstants.RED_BORDER_SHOW_ERROR;
+import static com.redhat.devtools.intellij.knative.ui.repository.RepositoryUtils.NATIVE_NAME;
 import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
 
 public class RepositoryDialog extends DialogWrapper {
@@ -59,6 +64,14 @@ public class RepositoryDialog extends DialogWrapper {
 
         @Override
         public Repository clone(@NotNull Repository item, boolean forInPlaceEditing) {
+            if (forInPlaceEditing) {
+                pendingChanges.removeIf(repo -> repo.getAttribute(NATIVE_NAME).equalsIgnoreCase(item.getAttribute(NATIVE_NAME)));
+                // the repository has being renamed. If it was an old existing one, we perform a rename
+                // if it was a new addition (still pending - not saved on cluster) we create it
+                updateChanges(item, RepositoryUtils.Operation.RENAME);
+                pendingChanges.add(item);
+                return item;
+            }
             if (pendingChanges.stream().noneMatch(repo -> repo.getName().equalsIgnoreCase(item.getName()))){
                 updateChanges(item, RepositoryUtils.Operation.CREATE);
                 pendingChanges.add(item);
@@ -85,31 +98,59 @@ public class RepositoryDialog extends DialogWrapper {
             return true;
         }
 
+        /**
+         * Update the list of changes to be made by keeping it cleaned.
+         * E.g. two renamed actions have been performed without having saved them? Only on rename action is in the list with the latest modification
+         * @param item item to add to the changes list
+         * @param operation the operation to be performed (CREATE, RENAME, DELETE)
+         */
         private void updateChanges(Repository item, RepositoryUtils.Operation operation) {
             Optional<RepositoryUtils.RepositoryChange> pendingChange = changes.stream()
                     .filter(repo -> repo.getRepository().equals(item))
                     .findFirst();
-            if (pendingChange.isPresent()) {
-                changes.remove(pendingChange.get());
-            } else {
+            if (operation.equals(RepositoryUtils.Operation.CREATE)) {
                 changes.add(new RepositoryUtils.RepositoryChange(item, operation));
+            } else if (operation.equals(RepositoryUtils.Operation.DELETE)) {
+                if (pendingChange.isPresent()) {
+                    changes.remove(pendingChange.get());
+                } else {
+                    changes.add(new RepositoryUtils.RepositoryChange(item, operation));
+                }
+            } else if (operation.equals(RepositoryUtils.Operation.RENAME)) {
+                Optional<RepositoryUtils.RepositoryChange> pendingCreationRenameChange = changes.stream()
+                        .filter(repo -> repo.getRepository().equals(item)
+                                && (repo.getOperation().equals(RepositoryUtils.Operation.CREATE)
+                                    || repo.getOperation().equals(RepositoryUtils.Operation.RENAME)))
+                        .findFirst();
+                if (pendingCreationRenameChange.isPresent()) {
+                    changes.remove(pendingCreationRenameChange.get());
+                    changes.add(new RepositoryUtils.RepositoryChange(item, pendingCreationRenameChange.get().getOperation()));
+                } else {
+                    changes.add(new RepositoryUtils.RepositoryChange(item, operation));
+                }
             }
             updateApplyButtonEnabling();
         }
     };
 
-    private final RepositoryModelEditor editor = new RepositoryModelEditor(itemEditor);
-
     private JComponent component;
     private JPanel itemPanelWrapper;
     private List<Repository> repositories, pendingChanges;
     private JTextField txtName, txtUrl;
+    private JLabel lblNameError, lblUrlError;
     private Kn kncli;
     private TelemetryMessageBuilder.ActionMessage telemetry;
 
+    private final RepositoryModelEditor editor = new RepositoryModelEditor(itemEditor, new Supplier<List<Repository>>() {
+        @Override
+        public List<Repository> get() {
+            return pendingChanges;
+        }
+    });
+
     public RepositoryDialog(@Nullable Project project, Kn kncli, List<Repository> repositories, TelemetryMessageBuilder.ActionMessage telemetry) {
         super(project, false);
-        this.repositories = repositories;
+        this.repositories = cloneList(repositories);
         this.pendingChanges = repositories;
         this.kncli = kncli;
         this.telemetry = telemetry;
@@ -118,6 +159,12 @@ public class RepositoryDialog extends DialogWrapper {
         updateApplyButtonEnabling();
         buildStructure(repositories);
         init();
+    }
+
+    private List<Repository> cloneList(List<Repository> repositories) {
+        List<Repository> finalRepos = new ArrayList<>();
+        repositories.forEach(repo -> finalRepos.add(repo.clone()));
+        return finalRepos;
     }
 
     public void buildStructure(List<Repository> repositories) {
@@ -146,14 +193,48 @@ public class RepositoryDialog extends DialogWrapper {
 
         itemPanelWrapper.add(descLabel, EMPTY);
         txtName = new JTextField();
-        txtName.setEditable(false);
         txtUrl = new JTextField();
         txtUrl.setEditable(false);
-        itemPanelWrapper.add(RepositoryUtils.createPanelRepository(txtName, txtUrl), PANEL);
+        lblNameError = new JLabel("Name cannot be empty and it must be unique.");
+        lblNameError.setVisible(false);
+        lblUrlError = new JLabel("Url format not valid. Only file uri scheme is supported.");
+        lblUrlError.setVisible(false);
+        JPanel out = RepositoryUtils.createPanelRepository(txtName, lblNameError, txtUrl, lblUrlError);
+        itemPanelWrapper.add(out, PANEL);
 
+        txtName.getDocument().addDocumentListener(new DocumentAdapter() {
+            @Override
+            protected void textChanged(@NotNull DocumentEvent e) {
+                Repository repo = editor.getSelected();
+                if (repo == null) {
+                    return;
+                }
+                String name = txtName.getText().trim();
+                if (name.equals(repo.getName())) {
+                    setError(false);
+                    return;
+                }
+                boolean validName = RepositoryUtils.isValidRepositoryName(name, repo.getAttribute(NATIVE_NAME), pendingChanges);
+
+                if (validName) {
+                    repo.setName(name);
+                    itemEditor.clone(repo, true);
+                }
+                setError(!validName);
+            }
+
+            private void setError(boolean isError) {
+                JTextField placeholder = new JTextField();
+                txtName.setBorder(!isError ? placeholder.getBorder() : RED_BORDER_SHOW_ERROR);
+                lblNameError.setVisible(isError);
+                component.invalidate();
+            }
+        });
 
         Splitter splitter = new Splitter(false, 0.3f);
+
         splitter.setFirstComponent(editor.createComponent());
+        splitter.getFirstComponent().setMinimumSize(new Dimension(150, Integer.MAX_VALUE));
         splitter.setSecondComponent(itemPanelWrapper);
         component = splitter;
     }
@@ -181,6 +262,8 @@ public class RepositoryDialog extends DialogWrapper {
                 try {
                     if (pendingChange.getOperation().equals(RepositoryUtils.Operation.CREATE)) {
                         doAddRepository(pendingChange.getRepository());
+                    } else if (pendingChange.getOperation().equals(RepositoryUtils.Operation.RENAME)) {
+                        doRenameRepository(pendingChange.getRepository());
                     } else if (pendingChange.getOperation().equals(RepositoryUtils.Operation.DELETE)) {
                         doRemoveRepository(pendingChange.getRepository());
                     }
@@ -208,6 +291,11 @@ public class RepositoryDialog extends DialogWrapper {
         sendAddNotification(repository);
     }
 
+    private void doRenameRepository(Repository repository) throws IOException {
+        kncli.renameRepo(repository);
+        sendRenameNotification(repository);
+    }
+
     private void doRemoveRepository(Repository repository) throws IOException {
         kncli.removeRepo(repository);
         sendRemoveNotification(repository);
@@ -226,11 +314,17 @@ public class RepositoryDialog extends DialogWrapper {
     }
 
     private void sendAddNotification(Repository repository) {
-        sendSuccessfulNotification("Added Successfully", repository.getName() + " has been saved!", repository.getName());
+        sendSuccessfulNotification("Repository Added", repository.getName() + " has been saved!", repository.getName());
+    }
+
+    private void sendRenameNotification(Repository repository) {
+        sendSuccessfulNotification("Repository Renamed",
+                repository.getAttribute(NATIVE_NAME) + " has been renamed to " + repository.getName(),
+                repository.getName());
     }
 
     private void sendRemoveNotification(Repository repository) {
-        sendSuccessfulNotification("Removed Successfully", repository.getName() + " has been removed!", repository.getName());
+        sendSuccessfulNotification("Repository Removed", repository.getName() + " has been removed!", repository.getName());
     }
 
     private void sendSuccessfulNotification(String title, String content, String repoName) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryDialog.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.repository;
+
+import com.intellij.openapi.keymap.impl.ui.KeymapListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.Splitter;
+import com.intellij.ui.CollectionListModel;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.ListItemEditor;
+import com.intellij.util.ui.ListModelEditor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Dimension;
+import java.util.Arrays;
+import java.util.List;
+
+public class RepositoryDialog extends DialogWrapper {
+
+    public static final String EMPTY = "empty";
+    public static final String PANEL = "panel";
+
+    private final ListItemEditor<Repository> itemEditor = new ListItemEditor<Repository>() {
+
+        @NotNull
+        @Override
+        public Class<Repository> getItemClass() {
+            return Repository.class;
+        }
+
+        @Override
+        public Repository clone(@NotNull Repository item, boolean forInPlaceEditing) {
+            return new Repository(item.getName(), item.getUrl());
+        }
+
+        @Override
+        public boolean isEmpty(@NotNull Repository item) {
+            return item.getName().isEmpty() && item.getUrl().isEmpty();
+        }
+
+        @NotNull
+        @Override
+        public String getName(@NotNull Repository item) {
+            return item.getName();
+        }
+
+        @Override
+        public boolean isRemovable(@NotNull Repository item) {
+            return true;
+        }
+    };
+
+    private final RepositoryModelEditor editor = new RepositoryModelEditor(itemEditor);
+
+    private JComponent component;
+    private JPanel itemPanelWrapper;
+    private List<Repository> repositories;
+    private JTextField txtName, txtUrl;
+
+    public RepositoryDialog(@Nullable Project project, List<Repository> repositories) {
+        super(project, false);
+        this.repositories = repositories;
+        setTitle("Repository");
+        setOKButtonText("Apply");
+        buildStructure(repositories);
+        init();
+    }
+
+    public void buildStructure(List<Repository> repositories) {
+        final CardLayout cardLayout = new CardLayout();
+        editor.getModel().add(repositories);
+
+        // doesn't make any sense (and in any case scheme manager cannot preserve order)
+        editor.disableUpDownActions();
+
+        editor.getList().addListSelectionListener(e -> {
+            Repository item = editor.getSelected();
+            if (item == null) {
+                cardLayout.show(itemPanelWrapper, EMPTY);
+            }
+            else {
+                txtName.setText(item.getName());
+                txtUrl.setText(item.getUrl());
+                cardLayout.show(itemPanelWrapper, PANEL);
+            }
+        });
+
+        itemPanelWrapper = new JPanel(cardLayout);
+
+        JLabel descLabel = new JLabel("<html>Repositories allow you to add and use new templates when creating a new Function.</html>");
+        descLabel.setBorder(JBUI.Borders.empty(0, 25));
+
+        itemPanelWrapper.add(descLabel, EMPTY);
+        txtName = new JTextField();
+        txtUrl = new JTextField();
+        itemPanelWrapper.add(RepositoryUtils.createPanelRepository(txtName, txtUrl), PANEL);
+
+
+        Splitter splitter = new Splitter(false, 0.3f);
+        splitter.setFirstComponent(editor.createComponent());
+        splitter.setSecondComponent(itemPanelWrapper);
+        component = splitter;
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        JPanel wrapper = new JPanel(new BorderLayout());
+        wrapper.add(component, BorderLayout.CENTER);
+        wrapper.setPreferredSize(new Dimension(550, 300));
+        return wrapper;
+    }
+
+    public CollectionListModel<Repository> getModel() {
+        return editor.getModel();
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
@@ -37,23 +37,23 @@ public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
         super(itemEditor);
 
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        list.setCellRenderer(SimpleListCellRenderer.create("", o -> itemEditor.getName(o)));
+        list.setCellRenderer(SimpleListCellRenderer.create("", itemEditor::getName));
 
         toolbarDecorator = ToolbarDecorator.createDecorator(list, model)
-                .setAddAction(button -> {
-                    if (!model.isEmpty()) {
-                        Repository lastItem = model.getElementAt(model.getSize() - 1);
-                        if (RepositoryModelEditor.this.itemEditor.isEmpty(lastItem)) {
-                            ScrollingUtil.selectItem(list, ContainerUtil.indexOfIdentity(model.getItems(), lastItem));
-                            return;
-                        }
-                    }
-
+                .setAddAction(action -> {
                     Repository item = createElement();
-                    model.add(item);
-                    ScrollingUtil.selectItem(list, ContainerUtil.indexOfIdentity(model.getItems(), item));
+                    if (item != null) {
+                        model.add(item);
+                        itemEditor.clone(item, false);
+                        ScrollingUtil.selectItem(list, ContainerUtil.indexOfIdentity(model.getItems(), item));
+                    }
                 })
-                .setRemoveActionUpdater(e -> areSelectedItemsRemovable(list.getSelectionModel()));
+                .setRemoveAction(action -> {
+                    Repository repositoryToDelete = list.getSelectedValue();
+                    if (itemEditor.isRemovable(repositoryToDelete)) {
+                        model.remove(repositoryToDelete);
+                    }
+                });
     }
 
     @Override
@@ -90,6 +90,6 @@ public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
 
     @Override
     protected void removeEmptyItem(int i) {
-        ListUtil.removeIndices(getList(), new int[]{i});
+        ListUtil.removeIndices(list, new int[]{i});
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
@@ -91,4 +91,8 @@ public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
     protected void removeEmptyItem(int i) {
         ListUtil.removeIndices(list, new int[]{i});
     }
+
+    protected void invalidate() {
+        model.update();
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
@@ -26,14 +26,14 @@ import javax.swing.JComponent;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import java.util.List;
-
+import java.util.function.Supplier;
 
 public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
     private final ToolbarDecorator toolbarDecorator;
 
     private final JBList<Repository> list = new JBList<>(model);
 
-    public RepositoryModelEditor(@NotNull ListItemEditor<Repository> itemEditor) {
+    public RepositoryModelEditor(@NotNull ListItemEditor<Repository> itemEditor, Supplier<List<Repository>> existingRepos) {
         super(itemEditor);
 
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -41,7 +41,7 @@ public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
 
         toolbarDecorator = ToolbarDecorator.createDecorator(list, model)
                 .setAddAction(action -> {
-                    Repository item = createElement();
+                    Repository item = createElement(existingRepos);
                     if (item != null) {
                         model.add(item);
                         itemEditor.clone(item, false);
@@ -56,10 +56,9 @@ public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
                 });
     }
 
-    @Override
-    public Repository createElement() {
+    public Repository createElement(Supplier<List<Repository>> existingRepos) {
         Repository repository = new Repository();
-        CreateRepositoryDialog createRepositoryDialog = new CreateRepositoryDialog(repository);
+        CreateRepositoryDialog createRepositoryDialog = new CreateRepositoryDialog(repository, existingRepos);
         createRepositoryDialog.show();
         if (createRepositoryDialog.isOK()) {
             return repository;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryModelEditor.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.repository;
+
+import com.intellij.ui.ListUtil;
+import com.intellij.ui.ScrollingUtil;
+import com.intellij.ui.SimpleListCellRenderer;
+import com.intellij.ui.ToolbarDecorator;
+import com.intellij.ui.components.JBList;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.ui.ListItemEditor;
+import com.intellij.util.ui.ListModelEditor;
+import com.intellij.util.ui.ListModelEditorBase;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComponent;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+import java.util.List;
+
+
+public class RepositoryModelEditor extends ListModelEditorBase<Repository> {
+    private final ToolbarDecorator toolbarDecorator;
+
+    private final JBList<Repository> list = new JBList<>(model);
+
+    public RepositoryModelEditor(@NotNull ListItemEditor<Repository> itemEditor) {
+        super(itemEditor);
+
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.setCellRenderer(SimpleListCellRenderer.create("", o -> itemEditor.getName(o)));
+
+        toolbarDecorator = ToolbarDecorator.createDecorator(list, model)
+                .setAddAction(button -> {
+                    if (!model.isEmpty()) {
+                        Repository lastItem = model.getElementAt(model.getSize() - 1);
+                        if (RepositoryModelEditor.this.itemEditor.isEmpty(lastItem)) {
+                            ScrollingUtil.selectItem(list, ContainerUtil.indexOfIdentity(model.getItems(), lastItem));
+                            return;
+                        }
+                    }
+
+                    Repository item = createElement();
+                    model.add(item);
+                    ScrollingUtil.selectItem(list, ContainerUtil.indexOfIdentity(model.getItems(), item));
+                })
+                .setRemoveActionUpdater(e -> areSelectedItemsRemovable(list.getSelectionModel()));
+    }
+
+    @Override
+    public Repository createElement() {
+        Repository repository = new Repository();
+        CreateRepositoryDialog createRepositoryDialog = new CreateRepositoryDialog(repository);
+        createRepositoryDialog.show();
+        if (createRepositoryDialog.isOK()) {
+            return repository;
+        }
+        return null;
+    }
+
+    @NotNull
+    public RepositoryModelEditor disableUpDownActions() {
+        toolbarDecorator.disableUpDownActions();
+        return this;
+    }
+
+    @NotNull
+    public JComponent createComponent() {
+        return toolbarDecorator.createPanel();
+    }
+
+    @NotNull
+    public JBList getList() {
+        return list;
+    }
+
+    @Nullable
+    public Repository getSelected() {
+        return list.getSelectedValue();
+    }
+
+    @Override
+    protected void removeEmptyItem(int i) {
+        ListUtil.removeIndices(getList(), new int[]{i});
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryUtils.java
@@ -17,19 +17,21 @@ import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.border.EmptyBorder;
+import javax.swing.SwingConstants;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.List;
 
 public class RepositoryUtils {
+    public static final String NATIVE_NAME = "native_name";
+
     public enum Operation {
         CREATE,
+        RENAME,
         DELETE
-    }
-
-    public static JPanel createPanelRepository(JTextField txtName, JTextField txtUrl) {
-        return createPanelRepository(txtName, null, txtUrl, null);
     }
 
     public static JPanel createPanelRepository(JTextField txtName, JLabel lblNameError, JTextField txtUrl, JLabel lblUrlError) {
@@ -54,10 +56,9 @@ public class RepositoryUtils {
         panel.setMaximumSize(ROW_DIMENSION);
         wrapper.add(panel);
         if (errorLabel != null) {
-            errorLabel.setPreferredSize(new Dimension(Integer.MAX_VALUE, 20));
-            errorLabel.setMinimumSize(new Dimension(Integer.MAX_VALUE, 20));
+            errorLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 20));
             errorLabel.setForeground(UIConstants.RED);
-            errorLabel.setBorder(JBUI.Borders.emptyLeft(60));
+            errorLabel.setHorizontalAlignment(SwingConstants.LEFT);
             wrapper.add(errorLabel);
         }
         return wrapper;
@@ -83,5 +84,21 @@ public class RepositoryUtils {
         public RepositoryChange clone() {
             return new RepositoryChange(getRepository(), getOperation());
         }
+    }
+
+    public static boolean isValidRepositoryName(String name, String nativeName, List<Repository> existingRepos) {
+        return !name.trim().isEmpty()
+                && (name.equals(nativeName)
+                || existingRepos.stream().noneMatch(repo -> repo.getName().equalsIgnoreCase(name)));
+    }
+
+    public static boolean isValidRepositoryUrl(String url) {
+        try {
+            URL u = new URL(url);
+            u.toURI();
+        } catch (MalformedURLException | URISyntaxException e) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryUtils.java
@@ -11,26 +11,40 @@
 package com.redhat.devtools.intellij.knative.ui.repository;
 
 import com.intellij.util.ui.JBUI;
+import com.redhat.devtools.intellij.knative.ui.UIConstants;
 
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.border.EmptyBorder;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.util.List;
 
 public class RepositoryUtils {
+    public enum Operation {
+        CREATE,
+        DELETE
+    }
+
     public static JPanel createPanelRepository(JTextField txtName, JTextField txtUrl) {
+        return createPanelRepository(txtName, null, txtUrl, null);
+    }
+
+    public static JPanel createPanelRepository(JTextField txtName, JLabel lblNameError, JTextField txtUrl, JLabel lblUrlError) {
         JPanel panelRepo = new JPanel();
         panelRepo.setLayout(new BoxLayout(panelRepo, BoxLayout.Y_AXIS));
         panelRepo.setBorder(JBUI.Borders.empty(0, 15));
 
-        panelRepo.add(createRepoFieldPanel("Name:", txtName));
-        panelRepo.add(createRepoFieldPanel("Url:", txtUrl));
+        panelRepo.add(createRepoFieldPanel("Name:", txtName, lblNameError));
+        panelRepo.add(createRepoFieldPanel("Url:", txtUrl, lblUrlError));
         return panelRepo;
     }
 
-    private static JPanel createRepoFieldPanel(String text, JTextField textField) {
+    private static JPanel createRepoFieldPanel(String text, JTextField textField, JLabel errorLabel) {
+        JPanel wrapper = new JPanel();
+        wrapper.setLayout(new BoxLayout(wrapper, BoxLayout.Y_AXIS));
         Dimension ROW_DIMENSION = new Dimension(Integer.MAX_VALUE, 40);
         JPanel panel = new JPanel(new BorderLayout());
         JLabel label = new JLabel(text);
@@ -38,7 +52,36 @@ public class RepositoryUtils {
         panel.add(label, BorderLayout.WEST);
         panel.add(textField, BorderLayout.CENTER);
         panel.setMaximumSize(ROW_DIMENSION);
-        return panel;
+        wrapper.add(panel);
+        if (errorLabel != null) {
+            errorLabel.setPreferredSize(new Dimension(Integer.MAX_VALUE, 20));
+            errorLabel.setMinimumSize(new Dimension(Integer.MAX_VALUE, 20));
+            errorLabel.setForeground(UIConstants.RED);
+            errorLabel.setBorder(JBUI.Borders.emptyLeft(60));
+            wrapper.add(errorLabel);
+        }
+        return wrapper;
     }
 
+    public static class RepositoryChange {
+        private Repository repository;
+        private Operation operation;
+
+        public RepositoryChange(Repository repository, Operation operation) {
+            this.repository = repository;
+            this.operation = operation;
+        }
+
+        public Repository getRepository() {
+            return repository;
+        }
+
+        public Operation getOperation() {
+            return operation;
+        }
+
+        public RepositoryChange clone() {
+            return new RepositoryChange(getRepository(), getOperation());
+        }
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/repository/RepositoryUtils.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.repository;
+
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+
+public class RepositoryUtils {
+    public static JPanel createPanelRepository(JTextField txtName, JTextField txtUrl) {
+        JPanel panelRepo = new JPanel();
+        panelRepo.setLayout(new BoxLayout(panelRepo, BoxLayout.Y_AXIS));
+        panelRepo.setBorder(JBUI.Borders.empty(0, 15));
+
+        panelRepo.add(createRepoFieldPanel("Name:", txtName));
+        panelRepo.add(createRepoFieldPanel("Url:", txtUrl));
+        return panelRepo;
+    }
+
+    private static JPanel createRepoFieldPanel(String text, JTextField textField) {
+        Dimension ROW_DIMENSION = new Dimension(Integer.MAX_VALUE, 40);
+        JPanel panel = new JPanel(new BorderLayout());
+        JLabel label = new JLabel(text);
+        label.setPreferredSize(new Dimension(60, 40));
+        panel.add(label, BorderLayout.WEST);
+        panel.add(textField, BorderLayout.CENTER);
+        panel.setMaximumSize(ROW_DIMENSION);
+        return panel;
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -91,9 +91,6 @@
         </group>
 
         <group id="com.redhat.devtools.intellij.knative.tree.functions" popup="true">
-            <action id="com.redhat.devtools.intellij.knative.actions.func.RepositoryAction"
-                    class="com.redhat.devtools.intellij.knative.actions.func.RepositoryAction"
-                    text="Repository"/>
             <reference id="com.redhat.devtools.intellij.knative.actions.OpenInBrowserAction"/>
             <action id="com.redhat.devtools.intellij.knative.actions.func.BuildAction"
                     class="com.redhat.devtools.intellij.knative.actions.func.BuildAction"
@@ -139,6 +136,9 @@
 
         <group id="com.redhat.devtools.intellij.knative.view.actionsFunctionToolbar">
             <reference id="com.redhat.devtools.intellij.knative.refresh"/>
+            <action id="com.redhat.devtools.intellij.knative.actions.func.RepositoryAction"
+                    class="com.redhat.devtools.intellij.knative.actions.func.RepositoryAction"
+                    text="Manage Repositories" icon="AllIcons.Actions.ListChanges"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -91,6 +91,9 @@
         </group>
 
         <group id="com.redhat.devtools.intellij.knative.tree.functions" popup="true">
+            <action id="com.redhat.devtools.intellij.knative.actions.func.RepositoryAction"
+                    class="com.redhat.devtools.intellij.knative.actions.func.RepositoryAction"
+                    text="Repository"/>
             <reference id="com.redhat.devtools.intellij.knative.actions.OpenInBrowserAction"/>
             <action id="com.redhat.devtools.intellij.knative.actions.func.BuildAction"
                     class="com.redhat.devtools.intellij.knative.actions.func.BuildAction"

--- a/src/main/resources/func.json
+++ b/src/main/resources/func.json
@@ -1,30 +1,30 @@
 {
   "tools": {
     "func": {
-      "version": "0.25.0",
+      "version": "0.26.0",
       "versionCmd": "version",
       "versionExtractRegExp": "v(\\d+[\\.\\d+]*)",
-      "versionMatchRegExpr": "0.25.0",
+      "versionMatchRegExpr": "0.26.0",
       "baseDir": "$HOME/.knative",
       "silentMode": true,
       "platforms": {
         "win": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_windows_amd64.exe",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_windows_amd64.exe",
           "cmdFileName": "func_windows_amd64.exe",
           "dlFileName": "func_windows_amd64.exe"
         },
         "osx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_darwin_amd64",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_darwin_amd64",
           "cmdFileName": "func_darwin_amd64",
           "dlFileName": "func_darwin_amd64"
         },
         "osx-arm64": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_darwin_arm64",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_darwin_arm64",
           "cmdFileName": "func_darwin_arm64",
           "dlFileName": "func_darwin_arm64"
         },
         "lnx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_linux_amd64",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_linux_amd64",
           "cmdFileName": "func_linux_amd64",
           "dlFileName": "func_linux_amd64"
         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -398,7 +398,7 @@ public class KnCliTest extends BaseTest {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             kn.createFunc(model);
             execHelperMockedStatic.verify(() ->
-                    ExecHelper.execute(anyString(), anyMap(), eq("create"), eq("path"), eq("-l"), eq("runtime"), eq("-t"), eq("template")));
+                    ExecHelper.execute(anyString(), anyMap(), eq("create"), eq("path"), eq("-l"), eq("runtime"), eq("-t"), eq("template"), eq("-n"), anyString()));
         }
     }
 


### PR DESCRIPTION
it resolves #97 

This patch adds complete support for repositories. Users can add/remove/rename repos from the wizard.
Once a new repo has been added, new templates can be seen when creating a new function.

![repositories](https://user-images.githubusercontent.com/49404737/187722723-20d09bed-80e9-45e9-9d66-7059868b8849.gif)
