### PR TITLE
feat: add tool window for builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ runIdeForUiTests {
 
 dependencies {
     compile 'io.fabric8:knative-client:5.7.4'
-    compile 'com.redhat.devtools.intellij:intellij-common:1.6.0'
+    compile 'com.redhat.devtools.intellij:intellij-common:1.7.0-SNAPSHOT'
     testCompile 'org.mockito:mockito-inline:3.8.0'
     compile 'com.squareup.okio:okio:1.15.0'
     // telemetry contributes annotations 13.0.0, so we need to declare newer version

--- a/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
@@ -26,6 +26,8 @@ public class Constants {
     public static final String KNATIVE_LOCAL_FUNC_TOOL_WINDOW_ID = "KnativeLocalFunction";
     public static final String BUILDFUNC_TOOLWINDOW_ID = "BuildFunc";
 
+    public static final String BUILDFUNC_CONTENT_NAME = "Build Output";
+
     public static final String[] YAML_NAME_PATH = new String[] { "metadata", "name" };
     public static final String[] YAML_FIRST_IMAGE_PATH = new String[] { "spec", "template", "spec", "containers[0]", "image" };
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
     public static final String KNATIVE_TOOL_WINDOW_ID = "Knative";
     public static final String KNATIVE_FUNC_TOOL_WINDOW_ID = "KnativeFunction";
     public static final String KNATIVE_LOCAL_FUNC_TOOL_WINDOW_ID = "KnativeLocalFunction";
+    public static final String BUILDFUNC_TOOLWINDOW_ID = "BuildFunc";
 
     public static final String[] YAML_NAME_PATH = new String[] { "metadata", "name" };
     public static final String[] YAML_FIRST_IMAGE_PATH = new String[] { "spec", "template", "spec", "containers[0]", "image" };

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
@@ -89,6 +89,10 @@ public class BuildAction extends KnAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn knCli) {
+        actionPerformed(anActionEvent, selected, knCli, true);
+    }
+
+    public void actionPerformed(AnActionEvent anActionEvent, Object selected, Kn knCli, boolean isBuild) {
         ParentableNode node = getElement(selected);
         Function function = ((KnFunctionNode) node).getFunction();
         TelemetryMessageBuilder.ActionMessage telemetry = createTelemetry();
@@ -99,11 +103,19 @@ public class BuildAction extends KnAction {
         }
 
         Project project = getEventProject(anActionEvent);
-        BuildFuncHandler buildFuncHandler = createBuildFuncHandler(project, function);
-        ProcessListener processListener = createBuildProcessListener(knCli, buildFuncHandler, function);
+        ConsoleView terminalExecutionConsole = null;
+        ProcessListener processListener = null;
+        if (isBuild) {
+            BuildFuncHandler buildFuncHandler = createBuildFuncHandler(project, function);
+            processListener = createBuildProcessListener(knCli, buildFuncHandler, function);
+            terminalExecutionConsole = buildFuncHandler.getTerminalExecutionConsole();
+        }
+
+        ConsoleView finalTerminalExecutionConsole = terminalExecutionConsole;
+        ProcessListener finalProcessListener = processListener;
         ExecHelper.submit(() -> doExecuteAction(project, function, registryAndImage.getFirst(),
-                registryAndImage.getSecond(), knCli, buildFuncHandler.getTerminalExecutionConsole(),
-                processListener, telemetry));
+                registryAndImage.getSecond(), knCli, finalTerminalExecutionConsole,
+                finalProcessListener, telemetry));
     }
 
     private BuildFuncHandler createBuildFuncHandler(Project project, Function function) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/DeployAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/DeployAction.java
@@ -11,6 +11,8 @@
 package com.redhat.devtools.intellij.knative.actions.func;
 
 import com.google.common.base.Strings;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.ui.Messages;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
@@ -38,7 +40,8 @@ public class DeployAction extends BuildAction {
     }
 
     @Override
-    protected void doExecute(CommonTerminalExecutionConsole terminalExecutionConsole, Kn knCli, String namespace, String localPathFunc, String registry, String image) throws IOException {
+    protected void doExecute(ConsoleView terminalExecutionConsole, ProcessListener processListener,
+                             Kn knCli, String namespace, String localPathFunc, String registry, String image) throws IOException {
         knCli.deployFunc(namespace, localPathFunc, registry, image);
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/DeployAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/DeployAction.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.intellij.knative.actions.func;
 import com.google.common.base.Strings;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.Messages;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
@@ -22,6 +23,7 @@ import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
 import com.redhat.devtools.intellij.knative.utils.FuncUtils;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 
+import javax.swing.tree.TreePath;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -37,6 +39,11 @@ public class DeployAction extends BuildAction {
 
     public DeployAction() {
         super();
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn knCli) {
+        actionPerformed(anActionEvent, selected, knCli, false);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/ShowBuildHistoryAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/ShowBuildHistoryAction.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions.toolbar;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.util.IconLoader;
+import com.redhat.devtools.intellij.knative.ui.buildFunc.BuildFuncPanel;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.Icon;
+
+public class ShowBuildHistoryAction  extends DumbAwareAction {
+
+    private BuildFuncPanel panel;
+    private static final Icon showHistoryIcon = AllIcons.General.InspectionsEye;
+
+    public ShowBuildHistoryAction(BuildFuncPanel panel) {
+        super("Show Function Build History", "Show function build history", showHistoryIcon);
+        this.panel = panel;
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        panel.switchShowHistoryMode();
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        if (panel.isShowHistory()) {
+            e.getPresentation().setText("Hide Function Build History");
+            e.getPresentation().setDescription("Hide function build history");
+            e.getPresentation().setIcon(IconLoader.getTransparentIcon(showHistoryIcon));
+        } else {
+            e.getPresentation().setText("Show Function Build History");
+            e.getPresentation().setDescription("Show function build history");
+            e.getPresentation().setIcon(showHistoryIcon);
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Function.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Function.java
@@ -22,6 +22,7 @@ public class Function {
     private String url;
     private boolean isReady;
     private boolean isPushed;
+    private boolean isBuilding;
     private String localPath;
 
     public Function(String name, String namespace, String runtime, String url, String image, boolean isReady, boolean isPushed, String localPath) {
@@ -32,6 +33,7 @@ public class Function {
         this.image = image;
         this.isReady = isReady;
         this.isPushed = isPushed;
+        this.isBuilding = false;
         this.localPath = localPath;
     }
 
@@ -75,5 +77,13 @@ public class Function {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public boolean isBuilding() {
+        return isBuilding;
+    }
+
+    public void setBuilding(boolean building) {
+        isBuilding = building;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.kn;
 
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
@@ -208,7 +210,7 @@ public interface Kn {
      * @param terminalExecutionConsole terminal tab to be used to run the command. If null a new tab will be created
      * @throws IOException if communication errored
      */
-    void buildFunc(String path, String registry, String image, CommonTerminalExecutionConsole terminalExecutionConsole) throws IOException;
+    void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
 
     /**
      * Deploy a function from path

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.kubernetes.ClusterHelper;
 import com.redhat.devtools.intellij.common.kubernetes.ClusterInfo;
@@ -301,8 +303,8 @@ public class KnCli implements Kn {
     }
 
     @Override
-    public void buildFunc(String path, String registry, String image, CommonTerminalExecutionConsole terminalExecutionConsole) throws IOException {
-        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, getBuildDeployArgs("build", "", path, registry, image, false));
+    public void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException {
+        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processListener, getBuildDeployArgs("build", "", path, registry, image, true));
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncExec.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncExec.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.buildFunc;
+
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.terminal.TerminalExecutionConsole;
+
+public class BuildFuncExec {
+
+    private String funcName;
+    private TerminalExecutionConsole terminalExecutionConsole;
+    private ProcessListener processListener;
+    private long startTime;
+    private long endTime;
+
+    public BuildFuncExec(String funcName){
+        this.funcName = funcName;
+        this.startTime = System.currentTimeMillis();
+        this.endTime = -1;
+    }
+
+    public String getFuncName() {
+        return funcName;
+    }
+
+    public TerminalExecutionConsole getTerminalExecutionConsole() {
+        return terminalExecutionConsole;
+    }
+
+    public void setTerminalExecutionConsole(TerminalExecutionConsole terminalExecutionConsole) {
+        this.terminalExecutionConsole = terminalExecutionConsole;
+    }
+
+    public ProcessListener getProcessListener() {
+        return processListener;
+    }
+
+    public void setProcessListener(ProcessListener processListener) {
+        this.processListener = processListener;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public long getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime() {
+        this.endTime = System.currentTimeMillis();
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncHandler.java
@@ -10,25 +10,72 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.ui.buildFunc;
 
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessListener;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
 import com.intellij.terminal.TerminalExecutionConsole;
+import com.intellij.ui.AnimatedIcon;
+import com.redhat.devtools.intellij.knative.kn.Function;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.Icon;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class BuildFuncHandler {
 
-    private String funcName;
+    private Project project;
+    private Function function;
     private TerminalExecutionConsole terminalExecutionConsole;
     private ProcessListener processListener;
     private long startTime;
     private long endTime;
+    private Icon[] stateIcon;
+    private String[] state;
 
-    public BuildFuncHandler(String funcName){
-        this.funcName = funcName;
+    public BuildFuncHandler(Project project, Function function){
+        this.project = project;
+        this.function = function;
         this.startTime = System.currentTimeMillis();
         this.endTime = -1;
+        init(project);
+    }
+
+    private void init(Project project) {
+        stateIcon = new Icon[]{new AnimatedIcon.FS()};
+        state = new String[]{"running ..."};
+        TerminalExecutionConsole commonTerminalExecutionConsole = new TerminalExecutionConsole(project, null);
+        ProcessListener processListener = new ProcessAdapter() {
+            @Override
+            public void processTerminated(@NotNull ProcessEvent event) {
+                if (event.getExitCode() == 0) {
+                    stateIcon[0] = AllIcons.RunConfigurations.TestPassed;
+                    state[0] =  "successful";
+                } else {
+                    stateIcon[0] = AllIcons.General.BalloonError;
+                    state[0] = "failed";
+                }
+                setEndTime();
+            }
+        };
+        setProcessListener(processListener);
+        setTerminalExecutionConsole(commonTerminalExecutionConsole);
+    }
+
+    public Project getProject() {
+        return project;
     }
 
     public String getFuncName() {
-        return funcName;
+        return function.getName();
+    }
+
+    public Function getFunction() {
+        return function;
     }
 
     public TerminalExecutionConsole getTerminalExecutionConsole() {
@@ -57,6 +104,28 @@ public class BuildFuncHandler {
 
     public void setEndTime() {
         this.endTime = System.currentTimeMillis();
+    }
+
+    public Icon getStateIcon() {
+        return stateIcon[0];
+    }
+
+    public String getState() {
+        return state[0];
+    }
+
+    public String getStartingDate() {
+        DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+        Date date = new Date(startTime);
+        return formatter.format(date);
+    }
+
+    public boolean isFinished() {
+        return endTime != -1;
+    }
+
+    public boolean isSuccessfullyCompleted() {
+        return state[0].equals("successful");
     }
 
     public void dispose() {

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncHandler.java
@@ -13,7 +13,7 @@ package com.redhat.devtools.intellij.knative.ui.buildFunc;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.terminal.TerminalExecutionConsole;
 
-public class BuildFuncExec {
+public class BuildFuncHandler {
 
     private String funcName;
     private TerminalExecutionConsole terminalExecutionConsole;
@@ -21,7 +21,7 @@ public class BuildFuncExec {
     private long startTime;
     private long endTime;
 
-    public BuildFuncExec(String funcName){
+    public BuildFuncHandler(String funcName){
         this.funcName = funcName;
         this.startTime = System.currentTimeMillis();
         this.endTime = -1;
@@ -57,5 +57,11 @@ public class BuildFuncExec {
 
     public void setEndTime() {
         this.endTime = System.currentTimeMillis();
+    }
+
+    public void dispose() {
+        if (terminalExecutionConsole != null) {
+            terminalExecutionConsole.dispose();
+        }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncPanel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncPanel.java
@@ -43,7 +43,6 @@ import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import java.awt.BorderLayout;
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -56,8 +55,8 @@ import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_CONTENT_N
 
 public class BuildFuncPanel extends ContentImpl {
 
-    private ToolWindow toolWindow;
-    private Map<String, List<BuildFuncHandler>> funcPerHandlers;
+    private final ToolWindow toolWindow;
+    private final Map<String, List<BuildFuncHandler>> funcPerHandlers;
     private JPanel terminalPanel;
     private DefaultTreeModel buildTreeModel;
     private Tree buildTree;
@@ -96,6 +95,9 @@ public class BuildFuncPanel extends ContentImpl {
         BuildFuncHandler buildFuncHandler = new BuildFuncHandler(project, function);
         List<BuildFuncHandler> buildFuncHandlers = funcPerHandlers.getOrDefault(function.getName(), new ArrayList<>());
         buildFuncHandlers.add(0, buildFuncHandler);
+        if (buildFuncHandlers.size() > 10) {
+            buildFuncHandlers.remove(10);
+        }
         funcPerHandlers.put(function.getName(), buildFuncHandlers);
 
         drawBuildFuncHandler(buildFuncHandlers);

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncPanel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncPanel.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.buildFunc;
+
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Divider;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.terminal.TerminalExecutionConsole;
+import com.intellij.ui.AnimatedIcon;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.OnePixelSplitter;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.content.impl.ContentImpl;
+import com.intellij.ui.treeStructure.Tree;
+import com.intellij.util.ui.UIUtil;
+import com.intellij.util.ui.tree.TreeUtil;
+import com.redhat.devtools.intellij.common.tree.LabelAndIconDescriptor;
+import com.redhat.devtools.intellij.knative.kn.Function;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeCellRenderer;
+import javax.swing.tree.TreePath;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.intellij.ide.plugins.PluginManagerConfigurable.SEARCH_FIELD_BORDER_COLOR;
+import static com.intellij.ui.AnimatedIcon.ANIMATION_IN_RENDERER_ALLOWED;
+
+public class BuildFuncPanel extends ContentImpl {
+
+    private ToolWindow toolWindow;
+    private Map<String, TerminalExecutionConsole> funcXTerminal;
+    private JPanel terminalPanel;
+    private DefaultTreeModel treeModel;
+    private Tree tree;
+
+    public BuildFuncPanel(ToolWindow toolWindow) {
+        super(null, "Build Output", true);
+        this.toolWindow = toolWindow;
+        this.funcXTerminal = new HashMap<>();
+        setComponent(createMainPanel());
+    }
+
+    public BuildFuncExec createViewBuildFunc(Project project, Function function) {
+        if (funcXTerminal.containsKey(function.getName())) {
+            funcXTerminal.get(function.getName()).dispose();
+            removeNode(function.getName());
+        }
+        final Icon[] nodeicon = {new AnimatedIcon.FS()};
+        final String[] location = {"running ..."};
+        BuildFuncExec buildFuncExec = new BuildFuncExec(function.getName());
+        DefaultMutableTreeNode buildNode = new DefaultMutableTreeNode(
+                new LabelAndIconDescriptor(project,
+                        buildFuncExec,
+                        () -> "Build " + function.getName() + ":",
+                        () -> location[0],
+                        () -> nodeicon[0],
+                        null));
+        treeModel.insertNodeInto(buildNode, (MutableTreeNode) treeModel.getRoot(), 0);
+
+        TerminalExecutionConsole commonTerminalExecutionConsole = new TerminalExecutionConsole(project, null);
+        ProcessListener processListener = new ProcessAdapter() {
+            @Override
+            public void processTerminated(@NotNull ProcessEvent event) {
+                if (event.getExitCode() == 0) {
+                    nodeicon[0] = AllIcons.RunConfigurations.TestPassed;
+                    location[0] =  "successful" +
+                            (function.getImage().isEmpty()
+                                    ? ""
+                                    : " <span style=\"color: gray;\">" + function.getImage() + "</span>");
+                } else {
+                    nodeicon[0] = AllIcons.General.BalloonError;
+                    location[0] = "failed";
+                }
+                buildFuncExec.setEndTime();
+            }
+        };
+        funcXTerminal.put(function.getName(), commonTerminalExecutionConsole);
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(commonTerminalExecutionConsole.getComponent(), BorderLayout.CENTER);
+        updateTerminalPanel(panel);
+
+
+        tree.invalidate();
+        tree.expandPath(new TreePath(((DefaultMutableTreeNode)treeModel.getRoot()).getPath()));
+        buildFuncExec.setProcessListener(processListener);
+        buildFuncExec.setTerminalExecutionConsole(commonTerminalExecutionConsole);
+        return buildFuncExec;
+    }
+
+    private void removeNode(String name) {
+        int children = treeModel.getChildCount(treeModel.getRoot());
+        for (int i = 0; i<children; i++) {
+            DefaultMutableTreeNode child = (DefaultMutableTreeNode) treeModel.getChild(treeModel.getRoot(), i);
+            String nodeName = ((BuildFuncExec)((LabelAndIconDescriptor)child.getUserObject()).getElement()).getFuncName();
+            if (nodeName.equals(name)) {
+                treeModel.removeNodeFromParent(child);
+                break;
+            }
+        }
+    }
+
+    private JComponent createMainPanel() {
+        OnePixelSplitter tabPanel = new OnePixelSplitter(false, 0.37F) {
+            protected Divider createDivider() {
+                Divider divider = super.createDivider();
+                divider.setBackground(SEARCH_FIELD_BORDER_COLOR);
+                return divider;
+            }
+        };
+        tabPanel.setFirstComponent(buildBuildsTree());
+        tabPanel.setSecondComponent(buildTerminalPanel());
+        return tabPanel;
+    }
+
+    private JComponent buildTerminalPanel() {
+        terminalPanel = new JPanel(new BorderLayout());
+        fillTerminalPanelWithMessage();
+        return terminalPanel;
+    }
+
+    private void fillTerminalPanelWithMessage() {
+        JLabel infoMessage = new JLabel("Nothing to show");
+        infoMessage.setEnabled(false);
+        infoMessage.setHorizontalAlignment(JLabel.CENTER);
+        updateTerminalPanel(infoMessage);
+    }
+
+    private void updateTerminalPanel(JComponent component) {
+        terminalPanel.removeAll();
+        terminalPanel.add(component, BorderLayout.CENTER);
+        terminalPanel.revalidate();
+        terminalPanel.repaint();
+    }
+
+    private void updateTerminalPanel(TerminalExecutionConsole console) {
+        terminalPanel.removeAll();
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(console.getComponent(), BorderLayout.CENTER);
+        terminalPanel.add(console.getComponent(), BorderLayout.CENTER);
+        terminalPanel.revalidate();
+        terminalPanel.repaint();
+    }
+
+    private JComponent buildBuildsTree() {
+        DefaultTreeModel treeModel = getTreeModel();
+        tree = new Tree(treeModel);
+        UIUtil.putClientProperty(tree, ANIMATION_IN_RENDERER_ALLOWED, true);
+        tree.setCellRenderer(getTreeCellRenderer());
+        tree.setVisible(true);
+        tree.setRootVisible(false);
+        return new JBScrollPane(tree);
+    }
+
+    private DefaultTreeModel getTreeModel() {
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode();
+        treeModel = new DefaultTreeModel(root);
+        return treeModel;
+    }
+
+    private TreeCellRenderer getTreeCellRenderer() {
+        return (tree1, value, selected, expanded, leaf, row, hasFocus) -> {
+            Object node = TreeUtil.getUserObject(value);
+
+            if (node instanceof LabelAndIconDescriptor) {
+                String funcName = ((BuildFuncExec)((LabelAndIconDescriptor<?>) node).getElement()).getFuncName();
+                if (selected && funcXTerminal.containsKey(funcName)) {
+                    updateTerminalPanel(funcXTerminal.get(funcName));
+                }
+
+                ((LabelAndIconDescriptor) node).update();
+                return createLabel(((LabelAndIconDescriptor) node).getPresentation().getPresentableText(),
+                        ((LabelAndIconDescriptor) node).getPresentation().getLocationString(),
+                        ((LabelAndIconDescriptor) node).getIcon(),
+                        (BuildFuncExec) ((LabelAndIconDescriptor<?>) node).getElement()
+                );
+            }
+            return null;
+        };
+    }
+
+    private JComponent createLabel(String name, String location, Icon icon, BuildFuncExec buildFuncExec) {
+        JPanel buildInfo = new JPanel(new BorderLayout());
+        String label = "<html><span style=\"font-weight: bold;\">" + name + "</span> ";
+        if (location != null && !location.isEmpty() ) {
+            label += location;
+        }
+        label += "</html>";
+        buildInfo.add(new JLabel(label, icon, SwingConstants.LEFT), BorderLayout.CENTER);
+
+        JLabel lblDuration = new JLabel(getDuration(buildFuncExec));
+        lblDuration.setForeground(JBColor.GRAY);
+        buildInfo.add(lblDuration, BorderLayout.EAST);
+        return buildInfo;
+    }
+
+    public String getDuration(BuildFuncExec buildFuncExec) {
+        long duration;
+        if (buildFuncExec.getEndTime() != -1) {
+            duration = buildFuncExec.getEndTime() - buildFuncExec.getStartTime();
+        } else {
+            duration = System.currentTimeMillis() - buildFuncExec.getStartTime();
+        }
+
+        String durationText = StringUtil.formatDurationApproximate(duration);
+        int index = durationText.indexOf("s ");
+        if (index != -1) {
+            durationText = durationText.substring(0, index + 1);
+        }
+        return durationText;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncWindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildFunc/BuildFuncWindowToolFactory.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.buildFunc;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class BuildFuncWindowToolFactory implements ToolWindowFactory {
+
+    @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        toolWindow.setIcon(AllIcons.Toolwindows.ToolWindowBuild);
+        toolWindow.setStripeTitle("Function Build");
+    }
+
+    @Override
+    public void init(ToolWindow window) {
+        BuildFuncPanel buildFuncPanel = new BuildFuncPanel(window);
+        window.getContentManager().addContent(buildFuncPanel);
+    }
+
+    @Override
+    public boolean shouldBeAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public boolean isDoNotActivateOnStart() {
+        return true;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Knative" anchor="left" factoryClass="com.redhat.devtools.intellij.knative.ui.toolwindow.WindowToolFactory" />
         <toolWindow id="KnativeFunction" anchor="left" factoryClass="com.redhat.devtools.intellij.knative.ui.toolwindow.FunctionsWindowToolFactory" />
+        <toolWindow id="BuildFunc" anchor="bottom" factoryClass="com.redhat.devtools.intellij.knative.ui.buildFunc.BuildFuncWindowToolFactory" canCloseContents="false" />
         <fileDocumentSynchronizationVetoer id="com.redhat.devtools.intellij.knative.listener.KnSaveInEditorListener" implementation="com.redhat.devtools.intellij.knative.listener.KnSaveInEditorListener" order="first" />
         <moduleBuilder builderClass="com.redhat.devtools.intellij.knative.ui.createFunc.FunctionModuleBuilder"/>
         <nonProjectFileWritingAccessExtension id="com.redhat.devtools.intellij.common.editor.AllowNonProjectEditing" implementation="com.redhat.devtools.intellij.common.editor.AllowNonProjectEditing" />

--- a/src/test/java/com/redhat/devtools/intellij/knative/BaseTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/BaseTest.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.intellij.knative;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.kn.KnCli;
+import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.tree.KnEventingBrokerNode;
 import com.redhat.devtools.intellij.knative.tree.KnEventingChannelsNode;
 import com.redhat.devtools.intellij.knative.tree.KnEventingNode;
@@ -62,6 +63,7 @@ public class BaseTest {
     protected KnEventingTriggersNode knEventingTriggersNode;
     protected KnSourceNode knSourceNode;
     protected KnSinkNode knSinkNode;
+    protected TelemetryService telemetryService;
     protected TelemetryMessageBuilder telemetryMessageBuilder;
     protected TelemetryMessageBuilder.ActionMessage actionMessage;
 
@@ -87,6 +89,7 @@ public class BaseTest {
         knFunctionNode = mock(KnFunctionNode.class);
         telemetryMessageBuilder = mock(TelemetryMessageBuilder.class);
         actionMessage = mock(TelemetryMessageBuilder.ActionMessage.class);
+
     }
 
     protected String load(String name) throws IOException {

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/ActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/ActionTest.java
@@ -12,6 +12,9 @@ package com.redhat.devtools.intellij.knative.actions;
 
 import com.intellij.ide.util.treeView.smartTree.TreeAction;
 import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.treeStructure.Tree;
 import com.redhat.devtools.intellij.knative.FixtureBaseTest;
 import com.redhat.devtools.intellij.knative.kn.Service;
@@ -20,10 +23,16 @@ import com.redhat.devtools.intellij.knative.kn.ServiceTraffic;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
+import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
+import com.redhat.devtools.intellij.knative.ui.buildFunc.BuildFuncHandler;
+import com.redhat.devtools.intellij.knative.ui.buildFunc.BuildFuncPanel;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import org.junit.Before;
+import org.mockito.MockedStatic;
 
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -67,4 +76,24 @@ public abstract class ActionTest extends FixtureBaseTest {
         when(serviceStatus.getUrl()).thenReturn("url");
     }
 
+    protected void mockToolWindow(MockedStatic<ToolWindowManager> toolWindowManagerMockedStatic) {
+        ToolWindowManager toolWindowManager = mock(ToolWindowManager.class);
+        toolWindowManagerMockedStatic.when(() -> ToolWindowManager.getInstance(any())).thenReturn(toolWindowManager);
+
+        ToolWindow toolWindow = mock(ToolWindow.class);
+        ContentManager contentManager = mock(ContentManager.class);
+        BuildFuncPanel buildFuncPanel = mock(BuildFuncPanel.class);
+        when(toolWindowManager.getToolWindow(anyString())).thenReturn(toolWindow);
+        when(toolWindow.getContentManager()).thenReturn(contentManager);
+        when(contentManager.findContent(anyString())).thenReturn(buildFuncPanel);
+        BuildFuncHandler buildFuncHandler = mock(BuildFuncHandler.class);
+        when(buildFuncPanel.createBuildFuncHandler(any(), any())).thenReturn(buildFuncHandler);
+    }
+
+    protected void mockTelemetry(MockedStatic<TelemetryService> telemetryServiceMockedStatic) {
+        telemetryServiceMockedStatic.when(TelemetryService::instance).thenReturn(telemetryMessageBuilder);
+        when(telemetryMessageBuilder.action(anyString())).thenReturn(actionMessage);
+        when(actionMessage.result(anyString())).thenReturn(actionMessage);
+        when(actionMessage.send()).thenReturn(null);
+    }
 }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
@@ -68,7 +68,7 @@ public class BuildActionTest extends ActionTest {
             when(kn.getNamespace()).thenReturn("namespace");
             treeHelperMockedStatic.when(() -> TreeHelper.getKn(any(Project.class))).thenReturn(kn);
             action.actionPerformed(anActionEvent);
-            verify(kn, times(0)).buildFunc(anyString(), anyString(), anyString(), any());
+            verify(kn, times(0)).buildFunc(anyString(), anyString(), anyString(), any(), any());
         }
     }
 
@@ -86,7 +86,7 @@ public class BuildActionTest extends ActionTest {
                     yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
                     action.actionPerformed(anActionEvent);
                     Thread.sleep(1000);
-                    verify(kn, times(1)).buildFunc(eq("path"), eq(""), eq("test"), eq(null));
+                    verify(kn, times(1)).buildFunc(eq("path"), eq(""), eq("test"), eq(null), eq(null));
                 }
             }
         }
@@ -108,7 +108,7 @@ public class BuildActionTest extends ActionTest {
                     yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("test").thenReturn("");
                     action.actionPerformed(anActionEvent);
                     Thread.sleep(1000);
-                    verify(kn, times(1)).buildFunc(eq("path"), eq("test"), eq(""), eq(null));
+                    verify(kn, times(1)).buildFunc(eq("path"), eq("test"), eq(""), eq(null), eq(null));
                 }
             }
         }
@@ -136,7 +136,7 @@ public class BuildActionTest extends ActionTest {
                         yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
                         action.actionPerformed(anActionEvent);
                         Thread.sleep(1000);
-                        verify(kn, times(1)).buildFunc(eq("path"), eq(""), eq("image"), eq(null));
+                        verify(kn, times(1)).buildFunc(eq("path"), eq(""), eq("image"), eq(null), eq(null));
                     }
                 }
             }
@@ -160,7 +160,7 @@ public class BuildActionTest extends ActionTest {
                         pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
                         action.actionPerformed(anActionEvent);
                         Thread.sleep(1000);
-                        verify(kn, times(1)).buildFunc(eq("path"), eq(null), eq("image"), eq(null));
+                        verify(kn, times(1)).buildFunc(eq("path"), eq(null), eq("image"), eq(null), eq(null));
                     }
                 }
 
@@ -186,7 +186,7 @@ public class BuildActionTest extends ActionTest {
                         yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenThrow(new IOException("error"));
                         action.actionPerformed(anActionEvent);
                         Thread.sleep(1000);
-                        verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null));
+                        verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null),eq(null));
                     }
                 }
             }
@@ -214,7 +214,7 @@ public class BuildActionTest extends ActionTest {
                         yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
                         action.actionPerformed(anActionEvent);
                         Thread.sleep(1000);
-                        verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null));
+                        verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null), eq(null));
                     }
                 }
             }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/DeleteActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/DeleteActionTest.java
@@ -10,23 +10,19 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.actions;
 
-import com.intellij.openapi.project.Project;
-import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class DeleteActionTest extends ActionTest {
 

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/DeployActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/DeployActionTest.java
@@ -20,6 +20,7 @@ import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.knative.Constants;
 import com.redhat.devtools.intellij.knative.actions.func.DeployAction;
 import com.redhat.devtools.intellij.knative.kn.Function;
+import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 import java.io.File;
 import java.io.IOException;
@@ -103,16 +104,19 @@ public class DeployActionTest extends ActionTest {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
                 try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
                     try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
-                        treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                        pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                        when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
-                        yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
-                        yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("image: test");
-                        yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
-                        messagesMockedStatic.when(() -> Messages.showOkCancelDialog(anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.CANCEL);
-                        action.actionPerformed(anActionEvent);
-                        Thread.sleep(1000);
-                        verify(kn, times(0)).deployFunc("namespace", "path", "", "test");
+                        try (MockedStatic<TelemetryService> telemetryServiceMockedStatic = mockStatic((TelemetryService.class))) {
+                            treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                            pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                            when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("image: test");
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
+                            messagesMockedStatic.when(() -> Messages.showOkCancelDialog(anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.CANCEL);
+                            mockTelemetry(telemetryServiceMockedStatic);
+                            action.actionPerformed(anActionEvent);
+                            Thread.sleep(1000);
+                            verify(kn, times(0)).deployFunc("namespace", "path", "", "test");
+                        }
                     }
                 }
             }

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.kn;
 
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.terminal.TerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.knative.BaseTest;
@@ -411,23 +413,29 @@ public class KnCliTest extends BaseTest {
 
     @Test
     public void BuildFunc_RegistryIsInsertedButNoImage_BuildIsCalled() throws IOException {
-        CommonTerminalExecutionConsole commonTerminalExecutionConsole = mock(CommonTerminalExecutionConsole.class);
+        TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
+        ProcessListener processListener = mock(ProcessListener.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "", commonTerminalExecutionConsole, null);
+            kn.buildFunc("path", "registry", "", terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
-                            any(CommonTerminalExecutionConsole.class), anyString(), eq("build"), eq("-r"), eq("registry"), eq("-p"), eq("path")));
+                            any(TerminalExecutionConsole.class), any(ProcessListener.class), anyString(),
+                            eq("build"), eq("-r"), eq("registry"), eq("-p"), eq("path"),
+                            eq("-v")));
         }
     }
 
     @Test
     public void BuildFunc_ImageIsInserted_BuildIsCalled() throws IOException {
-        CommonTerminalExecutionConsole commonTerminalExecutionConsole = mock(CommonTerminalExecutionConsole.class);
+        TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
+        ProcessListener processListener = mock(ProcessListener.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "image", commonTerminalExecutionConsole, null);
+            kn.buildFunc("path", "registry", "image", terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
-                            any(CommonTerminalExecutionConsole.class), anyString(), eq("build"), eq("-i"), eq("image"), eq("-p"), eq("path")));
+                            any(TerminalExecutionConsole.class), any(ProcessListener.class), anyString(),
+                            eq("build"), eq("-i"), eq("image"), eq("-p"), eq("path"),
+                            eq("-v")));
         }
     }
 

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -413,7 +413,7 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_RegistryIsInsertedButNoImage_BuildIsCalled() throws IOException {
         CommonTerminalExecutionConsole commonTerminalExecutionConsole = mock(CommonTerminalExecutionConsole.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "", commonTerminalExecutionConsole);
+            kn.buildFunc("path", "registry", "", commonTerminalExecutionConsole, null);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
                             any(CommonTerminalExecutionConsole.class), anyString(), eq("build"), eq("-r"), eq("registry"), eq("-p"), eq("path")));
@@ -424,7 +424,7 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_ImageIsInserted_BuildIsCalled() throws IOException {
         CommonTerminalExecutionConsole commonTerminalExecutionConsole = mock(CommonTerminalExecutionConsole.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "image", commonTerminalExecutionConsole);
+            kn.buildFunc("path", "registry", "image", commonTerminalExecutionConsole, null);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
                             any(CommonTerminalExecutionConsole.class), anyString(), eq("build"), eq("-i"), eq("image"), eq("-p"), eq("path")));
@@ -435,7 +435,7 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_ClientFails_Throws() {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             execHelperMockedStatic.when(() -> ExecHelper.executeWithTerminal(any(), anyString())).thenThrow(new IOException("error"));
-            kn.buildFunc("", "", "", null);
+            kn.buildFunc("", "", "", null, null);
         } catch (IOException e) {
             assertEquals("error", e.getLocalizedMessage());
         }


### PR DESCRIPTION
This is the stuff i'm working on. Still not completed but it's a good point to start a discussion. One of the biggest problem we have in both knative plugins are the multiple terminal tabs that gets opened when several actions are executed. This is the proposal for IJ for function builds. A custom tool window which shows the state of the builds with all logs on the terminal.
If you re-run multiple builds on the same function, the old node is replaced by the newest. Users can also see the final image  path next to the build name after it has been completed successfully. 

I think it would be cool to have this for `run` and `deploy` actions as well. How do you think they should work? Is it better to have everything in the same place? So on the left you would see multiple rows each for a different command `Build func- blabla:`, `Run func-blabla:`, `deploy func:blabla`? Or each command should have its own tab on the same toolwindow? Or create a specific tool window for each action? @mohitsuman @jeffmaury 

![build_tool_window](https://user-images.githubusercontent.com/49404737/166646960-5b69e3c3-4239-4c90-a9d1-b084b10ff645.gif)

This needs https://github.com/redhat-developer/intellij-common/pull/141 to work