### PR TITLE
fix: IDE stuck when plugin tries to watch func unsuccessfully

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/ClusterModelSynchronizer.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/ClusterModelSynchronizer.java
@@ -12,6 +12,8 @@ package com.redhat.devtools.intellij.knative.tree;
 
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 import com.redhat.devtools.intellij.knative.utils.WatchHandler;
+
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,7 +26,7 @@ public class ClusterModelSynchronizer {
         this.treeStructure = treeStructure;
     }
 
-    public void updateElementOnChange(KnRootNode element, String kindToWatch) {
+    public void updateElementOnChange(KnRootNode element, String kindToWatch) throws IOException {
         String id = TreeHelper.getId(element);
         resourceToNodeMapping.put(id, element);
         WatchHandler.get(element.getKn()).watchResource(id, kindToWatch, getUpdateRunnable(id));

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnFunctionsTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnFunctionsTreeStructure.java
@@ -153,7 +153,7 @@ public class KnFunctionsTreeStructure extends KnTreeStructure {
 
     private void setListenerOnFile(String path) {
         VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
-        VirtualFileListener virtualFileListener = getVirtualFileListener();
+        VirtualFileListener virtualFileListener = getVirtualFileListener(path);
         if (vf != null) {
             VirtualFileSystem virtualFileSystem = vf.getFileSystem();
             virtualFileSystem.addVirtualFileListener(virtualFileListener);
@@ -161,17 +161,21 @@ public class KnFunctionsTreeStructure extends KnTreeStructure {
         }
     }
 
-    private VirtualFileListener getVirtualFileListener() {
+    private VirtualFileListener getVirtualFileListener(String path) {
         Scheduler scheduler = new Scheduler(1000);
         return new VirtualFileListener() {
             @Override
             public void contentsChanged(@NotNull VirtualFileEvent event) {
-                scheduler.schedule(() -> TreeHelper.refreshFuncTree(project));
+                if (event.getFile().getPath().equals(path)) {
+                    scheduler.schedule(() -> TreeHelper.refreshFuncTree(project));
+                }
             }
 
             @Override
             public void fileDeleted(@NotNull VirtualFileEvent event) {
-                scheduler.schedule(() -> TreeHelper.refreshFuncTree(project));
+                if (event.getFile().getPath().equals(path)) {
+                    scheduler.schedule(() -> TreeHelper.refreshFuncTree(project));
+                }
             }
         };
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/WatchHandler.java
@@ -75,8 +75,7 @@ public class WatchHandler {
     }
 
     public void watchResource(String id, String kindToWatch, BiConsumer<Watcher.Action, Service> doExecute) {
-        if (!watches.containsKey(id)
-                && (!watchRetry.containsKey(id) || watchRetry.get(id) < 3)) {
+        if (isRetryable(id)) {
             try {
                 Watch watch = watchResource(kindToWatch, doExecute);
                 if (watch != null) {
@@ -84,9 +83,15 @@ public class WatchHandler {
                 }
             } catch (IOException e) {
                 int retry = watchRetry.getOrDefault(id, 0);
+
                 watchRetry.put(id, ++retry);
             }
         }
+    }
+
+    private boolean isRetryable(String id) {
+        return !watches.containsKey(id)
+                && (!watchRetry.containsKey(id) || watchRetry.get(id) < 3);
     }
 
     private Watch watchResource(String kindToWatch, BiConsumer<Watcher.Action, Service> doExecute) throws IOException {

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/WatchHandler.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/WatchHandler.java
@@ -50,8 +50,7 @@ public class WatchHandler {
     }
 
     public void watchResource(String id, String kindToWatch, Runnable doExecute) throws IOException {
-        if (!watches.containsKey(id)
-            && (!watchRetry.containsKey(id) || watchRetry.get(id) < 3)) {
+        if (isRetryable(id)) {
             try {
                 Watch watch = watchResource(kindToWatch, doExecute);
                 if (watch != null) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/watch/AbstractWatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/watch/AbstractWatcher.java
@@ -13,6 +13,8 @@ package com.redhat.devtools.intellij.knative.watch;
 import com.redhat.devtools.intellij.knative.kn.Kn;
 import io.fabric8.kubernetes.client.Watch;
 
+import java.io.IOException;
+
 public abstract class AbstractWatcher {
     protected Kn kn;
 
@@ -20,5 +22,5 @@ public abstract class AbstractWatcher {
         this.kn = kn;
     }
 
-    public abstract Watch doWatch(Runnable doExecute);
+    public abstract Watch doWatch(Runnable doExecute) throws IOException;
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/watch/FunctionWatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/watch/FunctionWatcher.java
@@ -33,13 +33,8 @@ public class FunctionWatcher extends AbstractWatcher {
         super(kn);
     }
 
-    public Watch doWatch(Runnable doExecute) {
-        try {
-            return kn.watchServiceWithLabel(FUNCTON_LABEL_KEY, "true", getWatcher(doExecute));
-        } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage(), e);
-        }
-        return null;
+    public Watch doWatch(Runnable doExecute) throws IOException {
+        return kn.watchServiceWithLabel(FUNCTON_LABEL_KEY, "true", getWatcher(doExecute));
     }
 
     private Watcher<io.fabric8.knative.serving.v1.Service> getWatcher(Runnable doExecute) {
@@ -56,13 +51,8 @@ public class FunctionWatcher extends AbstractWatcher {
         };
     }
 
-    public Watch doWatch(BiConsumer<Watcher.Action, Service> doExecute) {
-        try {
-            return kn.watchServiceWithLabel(FUNCTON_LABEL_KEY, "true", getWatcher(doExecute));
-        } catch (IOException e) {
-            logger.warn(e.getLocalizedMessage(), e);
-        }
-        return null;
+    public Watch doWatch(BiConsumer<Watcher.Action, Service> doExecute) throws IOException {
+        return kn.watchServiceWithLabel(FUNCTON_LABEL_KEY, "true", getWatcher(doExecute));
     }
 
     private Watcher<io.fabric8.knative.serving.v1.Service> getWatcher(BiConsumer<Watcher.Action, Service> doExecute) {


### PR DESCRIPTION
I made up a cluster with cluster-bot to do my demo but this had some issues as the cluster was extemely slow at responding and every time the plugin tried to watch resources it failed with `io.fabric8.kubernetes.client.KubernetesClientException: Failed to start websocket` . 
The problem is that the plugin retries to watch resources indefinitely so it can update the tree and the IDE gets stuck and it is unusable. If i was a user i would delete this immediately and leave 1 star. 
This patch adds a retry count to 3. If the plugin is not able to set the watch an warning message is displayed to the user that the plugin could have an unwanted behavior. In my case the tree wouldn't get refreshed automatically.  