### PR TITLE
feat: add stop func task action and allow only one active run per func

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ runIdeForUiTests {
 
 dependencies {
     compile 'io.fabric8:knative-client:5.7.4'
-    compile 'com.redhat.devtools.intellij:intellij-common:1.7.0-SNAPSHOT'
+    compile 'com.redhat.devtools.intellij:intellij-common:1.7.0'
     testCompile 'org.mockito:mockito-inline:3.8.0'
     compile 'com.squareup.okio:okio:1.15.0'
     // telemetry contributes annotations 13.0.0, so we need to declare newer version

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
@@ -104,8 +104,7 @@ public class BuildAction extends KnAction {
                         })
                 )
                 .build();
-
-        FuncActionPipelineManager.getInstance().start(buildPipeline);
+        knCli.getFuncActionPipelineManager().start(buildPipeline);
     }
 
     protected Pair<String, String> confirmAndGetRegistryImage(Function function, Kn knCli, TelemetryMessageBuilder.ActionMessage telemetry) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/DeployAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/DeployAction.java
@@ -11,8 +11,6 @@
 package com.redhat.devtools.intellij.knative.actions.func;
 
 import com.google.common.base.Strings;
-import com.intellij.execution.process.ProcessListener;
-import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Pair;
@@ -22,6 +20,7 @@ import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionTask;
 import com.redhat.devtools.intellij.knative.utils.FuncUtils;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 
@@ -52,14 +51,13 @@ public class DeployAction extends BuildAction {
 
         ExecHelper.submit(() -> {
             doExecuteAction(getEventProject(anActionEvent), function, registryAndImage.getFirst(),
-                    registryAndImage.getSecond(), knCli, null,
-                    null, telemetry);
+                    registryAndImage.getSecond(), knCli, null, telemetry);
         });
     }
 
     @Override
-    protected void doExecute(ConsoleView terminalExecutionConsole, ProcessListener processListener,
-                             Kn knCli, String namespace, String localPathFunc, String registry, String image) throws IOException {
+    protected void doExecute(FuncActionTask task, Kn knCli, String namespace,
+                             String localPathFunc, String registry, String image) throws IOException {
         knCli.deployFunc(namespace, localPathFunc, registry, image);
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RunAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/RunAction.java
@@ -64,7 +64,7 @@ public class RunAction extends KnAction {
                 .withTask("runFunc", (task) -> doRun(name, knCli, task, telemetry))
                 .build();
 
-        boolean isStarted = FuncActionPipelineManager.getInstance().start(runPipeline);
+        boolean isStarted = knCli.getFuncActionPipelineManager().start(runPipeline);
         if (!isStarted) {
             int response = Messages.showYesNoDialog(
                     project,
@@ -75,7 +75,7 @@ public class RunAction extends KnAction {
                     AllIcons.General.QuestionDialog
             );
             if (response == Messages.YES) {
-               FuncActionPipelineManager.getInstance().stopAndRerun(runPipeline);
+               knCli.getFuncActionPipelineManager().stopAndRerun(runPipeline);
             }
         }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/ShowFunctionTaskHistoryAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/ShowFunctionTaskHistoryAction.java
@@ -14,17 +14,17 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.util.IconLoader;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.BuildRunDeployFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.BuildRunDeployFuncPanel;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
 
-public class ShowBuildHistoryAction  extends DumbAwareAction {
+public class ShowFunctionTaskHistoryAction extends DumbAwareAction {
 
     private final BuildRunDeployFuncPanel panel;
     private static final Icon showHistoryIcon = AllIcons.General.InspectionsEye;
 
-    public ShowBuildHistoryAction(BuildRunDeployFuncPanel panel) {
+    public ShowFunctionTaskHistoryAction(BuildRunDeployFuncPanel panel) {
         super("Show Function Build History", "Show function build history", showHistoryIcon);
         this.panel = panel;
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/ShowFunctionTaskHistoryAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/ShowFunctionTaskHistoryAction.java
@@ -25,7 +25,7 @@ public class ShowFunctionTaskHistoryAction extends DumbAwareAction {
     private static final Icon showHistoryIcon = AllIcons.General.InspectionsEye;
 
     public ShowFunctionTaskHistoryAction(BuildRunDeployFuncPanel panel) {
-        super("Show Function Build History", "Show function build history", showHistoryIcon);
+        super("Show Action History", "Show function action execution history", showHistoryIcon);
         this.panel = panel;
     }
 
@@ -37,12 +37,12 @@ public class ShowFunctionTaskHistoryAction extends DumbAwareAction {
     @Override
     public void update(@NotNull AnActionEvent e) {
         if (panel.isShowHistory()) {
-            e.getPresentation().setText("Hide Function Build History");
-            e.getPresentation().setDescription("Hide function build history");
+            e.getPresentation().setText("Hide Action History");
+            e.getPresentation().setDescription("Hide function action execution history");
             e.getPresentation().setIcon(IconLoader.getTransparentIcon(showHistoryIcon));
         } else {
-            e.getPresentation().setText("Show Function Build History");
-            e.getPresentation().setDescription("Show function build history");
+            e.getPresentation().setText("Show Action History");
+            e.getPresentation().setDescription("Show function action execution history");
             e.getPresentation().setIcon(showHistoryIcon);
         }
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/StopFunctionTaskAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/StopFunctionTaskAction.java
@@ -25,7 +25,7 @@ public class StopFunctionTaskAction extends DumbAwareAction {
     private static final Icon showHistoryIcon = AllIcons.Actions.Suspend;
 
     public StopFunctionTaskAction(BuildRunDeployFuncPanel panel) {
-        super("Stop Function Task", "Stop function task execution", showHistoryIcon);
+        super("Stop Function Execution", "Stop function task execution", showHistoryIcon);
         this.panel = panel;
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/StopFunctionTaskAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/StopFunctionTaskAction.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions.toolbar;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.BuildRunDeployFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.IFuncAction;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.Icon;
+
+public class StopFunctionTaskAction extends DumbAwareAction {
+
+    private final BuildRunDeployFuncPanel panel;
+    private static final Icon showHistoryIcon = AllIcons.Actions.Suspend;
+
+    public StopFunctionTaskAction(BuildRunDeployFuncPanel panel) {
+        super("Stop Function Task", "Stop function task execution", showHistoryIcon);
+        this.panel = panel;
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        IFuncAction funcAction = panel.getSelectedFuncActionNode();
+        if (funcAction != null) {
+            funcAction.stop();
+        }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        IFuncAction funcAction = panel.getSelectedFuncActionNode();
+        e.getPresentation().setEnabled(funcAction != null && !funcAction.isFinished());
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -13,7 +13,9 @@ package com.redhat.devtools.intellij.knative.kn;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
+import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
+import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import io.fabric8.kubernetes.client.Watch;
@@ -210,7 +212,9 @@ public interface Kn {
      * @param terminalExecutionConsole terminal tab to be used to run the command. If null a new tab will be created
      * @throws IOException if communication errored
      */
-    void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
+    void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole,
+                   java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
+                   ProcessListener processListener) throws IOException;
 
     /**
      * Deploy a function from path
@@ -241,7 +245,9 @@ public interface Kn {
      * @param processListener
      * @throws IOException if communication errored
      */
-    void runFunc(String path, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
+    void runFunc(String path, ConsoleView terminalExecutionConsole,
+                 java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
+                 ProcessListener processListener) throws IOException;
 
     /**
      * Add environment variable to the function configuration

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipelineManager;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import io.fabric8.kubernetes.client.Watch;
@@ -298,4 +299,15 @@ public interface Kn {
      * @return a terminal console
      */
     CommonTerminalExecutionConsole createTerminalTabToReuse();
+
+    /**
+     * Return an instance of funcActionPipelineManager
+     * @return the FuncActionPipelineManager object
+     */
+    FuncActionPipelineManager getFuncActionPipelineManager();
+
+    /**
+     * dispose all resources created by kn
+     */
+    void dispose();
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -19,8 +19,10 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.kubernetes.ClusterHelper;
 import com.redhat.devtools.intellij.common.kubernetes.ClusterInfo;
+import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.common.utils.NetworkUtils;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
@@ -303,8 +305,11 @@ public class KnCli implements Kn {
     }
 
     @Override
-    public void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException {
-        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processListener, getBuildDeployArgs("build", "", path, registry, image, true));
+    public void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole,
+                          java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
+                          ProcessListener processListener) throws IOException {
+        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole,
+                processHandlerFunction, processListener, getBuildDeployArgs("build", "", path, registry, image, true));
     }
 
     @Override
@@ -379,8 +384,10 @@ public class KnCli implements Kn {
     }
 
     @Override
-    public void runFunc(String path, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException {
-        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processListener, funcCommand, "run", "-p", path);
+    public void runFunc(String path, ConsoleView terminalExecutionConsole,
+                        java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
+                        ProcessListener processListener) throws IOException {
+        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processHandlerFunction, processListener, funcCommand, "run", "-p", path);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -25,6 +25,7 @@ import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.common.utils.NetworkUtils;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipelineManager;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
@@ -66,12 +67,14 @@ public class KnCli implements Kn {
     private final String knCommand, funcCommand;
     private Map<String, String> envVars;
     private boolean hasKnativeServing, hasKnativeEventing;
+    private FuncActionPipelineManager funcActionPipelineManager;
 
     public KnCli(Project project, String knCommand, String funcCommand) {
         this.knCommand = knCommand;
         this.funcCommand = funcCommand;
         this.project = project;
         this.client = new DefaultKubernetesClient(new ConfigBuilder().build());
+        this.funcActionPipelineManager = new FuncActionPipelineManager();
         try {
             this.envVars = NetworkUtils.buildEnvironmentVariables(client.getMasterUrl().toString());
         } catch (URISyntaxException e) {
@@ -423,5 +426,13 @@ public class KnCli implements Kn {
     @Override
     public CommonTerminalExecutionConsole createTerminalTabToReuse() {
         return ExecHelper.createTerminalTabForReuse(project, KNATIVE_TOOL_WINDOW_ID);
+    }
+
+    public FuncActionPipelineManager getFuncActionPipelineManager() {
+        return funcActionPipelineManager;
+    }
+
+    public void dispose() {
+        funcActionPipelineManager.dispose();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnTreeStructure.java
@@ -272,11 +272,16 @@ public class KnTreeStructure extends AbstractKnTreeStructure implements ConfigWa
 
     protected void refresh() {
         try {
+            dispose();
             WatchHandler.get(null).removeAll();
             root.load().whenComplete((kn, err) -> {
                 mutableModelSupport.fireModified(root);
             });
         } catch (Exception e) {
         }
+    }
+
+    public void dispose() {
+        root.getKn().dispose();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnTreeStructure.java
@@ -272,16 +272,11 @@ public class KnTreeStructure extends AbstractKnTreeStructure implements ConfigWa
 
     protected void refresh() {
         try {
-            dispose();
             WatchHandler.get(null).removeAll();
             root.load().whenComplete((kn, err) -> {
                 mutableModelSupport.fireModified(root);
             });
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
-    }
-
-    public void dispose() {
-        root.getKn().dispose();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/ActionFuncHandlerListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/ActionFuncHandlerListener.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
+
+public interface ActionFuncHandlerListener {
+    void fireModified(FuncActionPipeline element);
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/BuildRunDeployFuncPanel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/BuildRunDeployFuncPanel.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.actionSystem.ActionManager;
@@ -27,7 +27,8 @@ import com.intellij.ui.content.impl.ContentImpl;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.tree.TreeUtil;
-import com.redhat.devtools.intellij.knative.actions.toolbar.ShowBuildHistoryAction;
+import com.redhat.devtools.intellij.knative.actions.toolbar.ShowFunctionTaskHistoryAction;
+import com.redhat.devtools.intellij.knative.actions.toolbar.StopFunctionTaskAction;
 import com.redhat.devtools.intellij.knative.utils.UIUtils;
 
 import javax.swing.Icon;
@@ -43,6 +44,7 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import java.awt.BorderLayout;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -92,8 +94,9 @@ public abstract class BuildRunDeployFuncPanel extends ContentImpl {
     }
 
     protected List<AnAction> getToolbarActions() {
-        return Collections.singletonList(
-                new ShowBuildHistoryAction(this)
+        return Arrays.asList(
+                new ShowFunctionTaskHistoryAction(this),
+                new StopFunctionTaskAction(this)
         );
     }
 
@@ -376,5 +379,14 @@ public abstract class BuildRunDeployFuncPanel extends ContentImpl {
         return !funcAction.isSuccessfullyCompleted() ?
                 funcAction.getState() :
                 funcAction.getState() + " <span style=\"color: gray;\">At " + funcAction.getStartingDate() + "</span>";
+    }
+
+    public IFuncAction getSelectedFuncActionNode() {
+        Object pathComponent = buildTree.getLastSelectedPathComponent();
+        Object node = TreeUtil.getUserObject(pathComponent);
+        if (node instanceof FuncActionNodeDescriptor) {
+            return ((FuncActionNodeDescriptor) node).getElement();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionNodeDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionNodeDescriptor.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.project.Project;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipeline.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipeline.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class FuncActionPipeline implements IFuncAction {
+public class FuncActionPipeline implements IFuncActionPipeline {
 
     protected final Project project;
     private final Function function;
@@ -62,6 +62,11 @@ public class FuncActionPipeline implements IFuncAction {
 
     public String getActionName() {
         return actionName;
+    }
+
+    @Override
+    public void stop() {
+        runningStep.stop();
     }
 
     public Project getProject() {

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipelineBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipelineBuilder.java
@@ -8,48 +8,48 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
 import com.redhat.devtools.intellij.knative.kn.Function;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab.BuildFuncActionPipeline;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab.BuildFuncActionTask;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.runFuncWindowTab.RunFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab.RunFuncActionPipeline;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class FuncActionsPipelineBuilder {
+public class FuncActionPipelineBuilder {
 
     private final List<FuncActionTask> tasks = new ArrayList<>();
     private FuncActionPipeline pipeline;
 
-    public FuncActionsPipelineBuilder(){}
+    public FuncActionPipelineBuilder(){}
 
-    public FuncActionsPipelineBuilder createBuildPipeline(Project project, Function function) {
+    public FuncActionPipelineBuilder createBuildPipeline(Project project, Function function) {
         pipeline = new BuildFuncActionPipeline(project, function);
         return this;
     }
 
-    public FuncActionsPipelineBuilder createRunPipeline(Project project, Function function) {
+    public FuncActionPipelineBuilder createRunPipeline(Project project, Function function) {
         pipeline = new RunFuncActionPipeline(project, function);
         return this;
     }
 
-    public FuncActionsPipelineBuilder withBuildTask(Consumer<FuncActionTask> doExecute) {
+    public FuncActionPipelineBuilder withBuildTask(Consumer<FuncActionTask> doExecute) {
         int taskIndex = tasks.size();
         tasks.add(taskIndex, new BuildFuncActionTask(pipeline, doExecute, taskIndex));
         return this;
     }
 
-    public FuncActionsPipelineBuilder withTask(String name, Consumer<FuncActionTask> doExecute) {
+    public FuncActionPipelineBuilder withTask(String name, Consumer<FuncActionTask> doExecute) {
         int taskIndex = tasks.size();
         tasks.add(taskIndex, new FuncActionTask(pipeline, name, doExecute, taskIndex));
         return this;
     }
 
-    public FuncActionPipeline build() {
+    public IFuncActionPipeline build() {
         if (pipeline != null) {
             pipeline.setTasks(tasks);
         }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipelineManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipelineManager.java
@@ -20,18 +20,10 @@ import java.util.Optional;
 
 public class FuncActionPipelineManager {
 
-    private static FuncActionPipelineManager INSTANCE;
     private final Map<String, List<IFuncActionPipeline>> pipelines;
 
-    private FuncActionPipelineManager(){
+    public FuncActionPipelineManager(){
         pipelines = new HashMap<>();
-    }
-
-    public static FuncActionPipelineManager getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new FuncActionPipelineManager();
-        }
-        return INSTANCE;
     }
 
     public boolean start(IFuncActionPipeline pipeline) {
@@ -74,5 +66,13 @@ public class FuncActionPipelineManager {
         pipelinesFunction.add(pipeline);
         pipelines.put(pipeline.getFuncName(), pipelinesFunction);
         return true;
+    }
+
+    public void dispose() {
+        pipelines.values().forEach(pipelinesPerFunction -> pipelinesPerFunction.forEach(pipeline -> {
+            if (!pipeline.isFinished()) {
+                pipeline.stop();
+            }
+        }));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipelineManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionPipelineManager.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
+
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab.RunFuncActionPipeline;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FuncActionPipelineManager {
+
+    private static FuncActionPipelineManager INSTANCE;
+    private final Map<String, List<IFuncActionPipeline>> pipelines;
+
+    private FuncActionPipelineManager(){
+        pipelines = new HashMap<>();
+    }
+
+    public static FuncActionPipelineManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new FuncActionPipelineManager();
+        }
+        return INSTANCE;
+    }
+
+    public boolean start(IFuncActionPipeline pipeline) {
+        if (canBeStarted(pipeline)) {
+            ((FuncActionPipeline)pipeline).start();
+            return true;
+        }
+        return false;
+    }
+
+    public void stopAndRerun(IFuncActionPipeline pipeline) {
+        stop(pipeline);
+        start(pipeline);
+    }
+
+    private void stop(IFuncActionPipeline pipeline) {
+        List<IFuncActionPipeline> pipelinesFunction = pipelines.getOrDefault(pipeline.getFuncName(), new ArrayList<>());
+        Optional<IFuncActionPipeline> existingActionPipeline = pipelinesFunction.stream()
+                .filter(funcActionPipeline -> funcActionPipeline.getActionName().equals(pipeline.getActionName()))
+                .findFirst();
+        if (existingActionPipeline.isPresent()) {
+            pipelinesFunction.remove(existingActionPipeline.get());
+            existingActionPipeline.get().stop();
+            pipelines.put(pipeline.getFuncName(), pipelinesFunction);
+        }
+    }
+
+    private boolean canBeStarted(IFuncActionPipeline pipeline) {
+        List<IFuncActionPipeline> pipelinesFunction = pipelines.getOrDefault(pipeline.getFuncName(), new ArrayList<>());
+        Optional<IFuncActionPipeline> existingActionPipeline = pipelinesFunction.stream()
+                .filter(funcActionPipeline -> funcActionPipeline.getActionName().equals(pipeline.getActionName()))
+                .findFirst();
+        if (existingActionPipeline.isPresent()) {
+            if (existingActionPipeline.get() instanceof RunFuncActionPipeline
+                && !existingActionPipeline.get().isFinished()) {
+                return false;
+            }
+            pipelinesFunction.remove(existingActionPipeline.get());
+        }
+        pipelinesFunction.add(pipeline);
+        pipelines.put(pipeline.getFuncName(), pipelinesFunction);
+        return true;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionTask.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/FuncActionTask.java
@@ -8,8 +8,9 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
+import com.intellij.execution.process.KillableProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessListener;
@@ -18,6 +19,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.terminal.TerminalExecutionConsole;
 import com.intellij.ui.AnimatedIcon;
 import com.intellij.util.Consumer;
+import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
+import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.kn.Function;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,6 +33,8 @@ public class FuncActionTask implements IFuncAction {
     protected final FuncActionPipeline actionFuncHandler;
     private final String actionName;
     private TerminalExecutionConsole terminalExecutionConsole;
+    private ExecProcessHandler runHandler;
+    protected java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction;
     private ProcessListener processListener;
     private long startTime;
     private long endTime;
@@ -81,6 +86,13 @@ public class FuncActionTask implements IFuncAction {
         };
         setProcessListener(processListener);
         setTerminalExecutionConsole(commonTerminalExecutionConsole);
+        setProcessHandlerFunction();
+    }
+
+    public void stop() {
+        if (runHandler != null && !isFinished()) {
+            runHandler.destroyProcess();
+        }
     }
 
     public String getActionName() {
@@ -166,5 +178,18 @@ public class FuncActionTask implements IFuncAction {
 
     public int getStepIndex() {
         return stepIndex;
+    }
+
+    private void setProcessHandlerFunction() {
+        processHandlerFunction = processHandlerInput -> {
+                                        runHandler = new ExecProcessHandler(processHandlerInput.getProcess(),
+                                                processHandlerInput.getCommandLine(),
+                                                processHandlerInput.getCharset());
+                                        return runHandler;
+                                    };
+    }
+
+    public java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> getProcessHandlerFunction() {
+        return processHandlerFunction;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/IFuncAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/IFuncAction.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.knative.kn.Function;
@@ -36,5 +36,5 @@ public interface IFuncAction {
 
     String getStartingDate();
 
-
+    void stop();
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/IFuncActionPipeline.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/IFuncActionPipeline.java
@@ -8,8 +8,10 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow;
 
-public interface ActionFuncHandlerListener {
-    void fireModified(FuncActionPipeline element);
+public interface IFuncActionPipeline extends IFuncAction {
+
+    String getActionName();
+
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/buildFuncWindowTab/BuildFuncActionPipeline.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/buildFuncWindowTab/BuildFuncActionPipeline.java
@@ -8,13 +8,13 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.redhat.devtools.intellij.knative.kn.Function;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipeline;
 
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_CONTENT_NAME;
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_TOOLWINDOW_ID;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/buildFuncWindowTab/BuildFuncActionTask.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/buildFuncWindowTab/BuildFuncActionTask.java
@@ -8,13 +8,13 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab;
 
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.Consumer;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionPipeline;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionTask;
 
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_CONTENT_NAME;
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_TOOLWINDOW_ID;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/buildFuncWindowTab/BuildFuncPanel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/buildFuncWindowTab/BuildFuncPanel.java
@@ -8,11 +8,11 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab;
 
 import com.intellij.openapi.wm.ToolWindow;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.BuildRunDeployFuncPanel;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.IFuncAction;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.BuildRunDeployFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.IFuncAction;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.util.List;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/runFuncWindowTab/RunFuncActionPipeline.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/runFuncWindowTab/RunFuncActionPipeline.java
@@ -8,13 +8,13 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow.runFuncWindowTab;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.redhat.devtools.intellij.knative.kn.Function;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipeline;
 
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_TOOLWINDOW_ID;
 import static com.redhat.devtools.intellij.knative.Constants.RUNFUNC_CONTENT_NAME;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/runFuncWindowTab/RunFuncPanel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/buildRunDeployWindow/runFuncWindowTab/RunFuncPanel.java
@@ -8,14 +8,14 @@
  * Contributors:
  * Red Hat, Inc.
  ******************************************************************************/
-package com.redhat.devtools.intellij.knative.ui.brdWindow.runFuncWindowTab;
+package com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab;
 
 import com.intellij.openapi.wm.ToolWindow;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.BuildRunDeployFuncPanel;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionPipeline;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionTask;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.IFuncAction;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab.BuildFuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.BuildRunDeployFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.IFuncAction;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncActionTask;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.util.Collections;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/toolwindow/BuildRunDeployWindowToolFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/toolwindow/BuildRunDeployWindowToolFactory.java
@@ -16,9 +16,9 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.ContentManagerEvent;
 import com.intellij.ui.content.ContentManagerListener;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.BuildRunDeployFuncPanel;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab.BuildFuncPanel;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.runFuncWindowTab.RunFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.BuildRunDeployFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab.RunFuncPanel;
 import org.jetbrains.annotations.NotNull;
 
 public class BuildRunDeployWindowToolFactory implements ToolWindowFactory {

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/ActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/ActionTest.java
@@ -24,7 +24,8 @@ import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab.BuildFuncPanel;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipelineManager;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncPanel;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import org.junit.Before;
 import org.mockito.MockedStatic;
@@ -46,6 +47,7 @@ public abstract class ActionTest extends FixtureBaseTest {
     protected Presentation presentation;
     protected TreeAction treeAction;
     protected TelemetryMessageBuilder.ActionMessage telemetry;
+    protected FuncActionPipelineManager manager;
 
 
     @Before
@@ -64,6 +66,7 @@ public abstract class ActionTest extends FixtureBaseTest {
         treeAction = mock(TreeAction.class);
         telemetry = mock(TelemetryMessageBuilder.ActionMessage.class);
         presentation = new Presentation();
+        manager = mock(FuncActionPipelineManager.class);
 
         when(path.getLastPathComponent()).thenReturn(knServiceNode);
         when(path1.getLastPathComponent()).thenReturn(knRevisionNode);

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/ActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/ActionTest.java
@@ -76,6 +76,8 @@ public abstract class ActionTest extends FixtureBaseTest {
         when(model.getSelectionPaths()).thenReturn(new TreePath[] {path});
         when(tree.getSelectionModel()).thenReturn(model);
         when(serviceStatus.getUrl()).thenReturn("url");
+
+        when(kn.getFuncActionPipelineManager()).thenReturn(manager);
     }
 
     protected void mockToolWindow(MockedStatic<ToolWindowManager> toolWindowManagerMockedStatic) {

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
@@ -24,8 +24,9 @@ import com.redhat.devtools.intellij.knative.Constants;
 import com.redhat.devtools.intellij.knative.actions.func.BuildAction;
 import com.redhat.devtools.intellij.knative.kn.Function;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionTask;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.buildFuncWindowTab.BuildFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionPipelineManager;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncActionPipeline;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,7 +85,7 @@ public class BuildActionTest extends ActionTest {
                         mockToolWindow(toolWindowManagerMockedStatic);
                         mockTelemetry(telemetryServiceMockedStatic);
                         action.actionPerformed(anActionEvent);
-                        verify(kn, times(0)).buildFunc(anyString(), anyString(), anyString(), any(), any());
+                        verify(kn, times(0)).buildFunc(anyString(), anyString(), anyString(), any(), any(), any());
                     }
                 }
             }
@@ -103,6 +104,9 @@ public class BuildActionTest extends ActionTest {
                                 (mock, context) -> {
                                     doNothing().when(mock).start();
                                 })) {
+                            try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
+
+                                funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
                                 treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
                                 pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
                                 yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
@@ -110,7 +114,8 @@ public class BuildActionTest extends ActionTest {
                                 yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
                                 action.actionPerformed(anActionEvent);
                                 Thread.sleep(1000);
-                                verify(buildFuncActionPipelineMockedConstruction.constructed().get(0), times(1)).start();
+                                verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+                            }
                         }
                     }
                 }
@@ -167,18 +172,21 @@ public class BuildActionTest extends ActionTest {
                                     (mock, context) -> {
                                         doNothing().when(mock).start();
                                     })) {
+                                try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
+                                    funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
+                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                    when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
 
 
-                                action.actionPerformed(anActionEvent);
-                                Thread.sleep(1000);
-                                verify(buildFuncActionPipelineMockedConstruction.constructed().get(0), times(1)).start();
+                                    action.actionPerformed(anActionEvent);
+                                    Thread.sleep(1000);
+                                    verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+                                }
                             }
                         }
                     }
@@ -211,14 +219,17 @@ public class BuildActionTest extends ActionTest {
                                             (mock, context) -> {
                                                 doNothing().when(mock).start();
                                             })) {
+                                        try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                        treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                        pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                        mockToolWindow(toolWindowManagerMockedStatic);
-                                        mockTelemetry(telemetryServiceMockedStatic);
-                                        action.actionPerformed(anActionEvent);
-                                        Thread.sleep(1000);
-                                        verify(buildFuncActionPipelineMockedConstruction.constructed().get(0), times(1)).start();
+                                            funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
+                                            treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                            pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                            mockToolWindow(toolWindowManagerMockedStatic);
+                                            mockTelemetry(telemetryServiceMockedStatic);
+                                            action.actionPerformed(anActionEvent);
+                                            Thread.sleep(1000);
+                                            verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+                                        }
                                     }
                                 }
                             }
@@ -245,15 +256,19 @@ public class BuildActionTest extends ActionTest {
                         })) {
                         try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
                             try(MockedConstruction<BuildFuncActionPipeline> buildFuncActionPipelineMockedConstruction = mockConstruction(BuildFuncActionPipeline.class,
-                                    (mock, context) -> {
-                                        doNothing().when(mock).start();
-                                    })) {
+                                (mock, context) -> {
+                                    doNothing().when(mock).start();
+                                })) {
+                                try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
+
+                                    funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
                                     treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
                                     pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
                                     yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenThrow(new IOException("error"));
                                     action.actionPerformed(anActionEvent);
                                     Thread.sleep(1000);
-                                    verify(buildFuncActionPipelineMockedConstruction.constructed().get(0), times(1)).start();
+                                    verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+                                }
 
                             }
                         }
@@ -293,7 +308,7 @@ public class BuildActionTest extends ActionTest {
                                     mockTelemetry(telemetryServiceMockedStatic);
                                     action.actionPerformed(anActionEvent);
                                     Thread.sleep(1000);
-                                    verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null), eq(null));
+                                    verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null), eq(null), eq(null));
                                 }
                             }
                         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
@@ -104,18 +104,16 @@ public class BuildActionTest extends ActionTest {
                                 (mock, context) -> {
                                     doNothing().when(mock).start();
                                 })) {
-                            try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
-                                treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("image: test");
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
-                                action.actionPerformed(anActionEvent);
-                                Thread.sleep(1000);
-                                verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
-                            }
+                            treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                            pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("image: test");
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
+                            action.actionPerformed(anActionEvent);
+                            Thread.sleep(1000);
+                            verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+
                         }
                     }
                 }
@@ -136,21 +134,18 @@ public class BuildActionTest extends ActionTest {
                                 (mock, context) -> {
                                     doNothing().when(mock).start();
                                 })) {
-                            try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
-                                treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("registry: test");
-                                yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("test").thenReturn("");
+                            treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                            pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                            when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("registry: test");
+                            yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("test").thenReturn("");
 
-                                action.actionPerformed(anActionEvent);
-                                Thread.sleep(1000);
+                            action.actionPerformed(anActionEvent);
+                            Thread.sleep(1000);
 
-                                verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
-                            }
+                            verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
                         }
                     }
                 }
@@ -176,21 +171,19 @@ public class BuildActionTest extends ActionTest {
                                     (mock, context) -> {
                                         doNothing().when(mock).start();
                                     })) {
-                                try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                    funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
-                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                    when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
-                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
-                                    yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
-                                    yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
+                                treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                                yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
+                                yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
 
 
-                                    action.actionPerformed(anActionEvent);
-                                    Thread.sleep(1000);
-                                    verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
-                                }
+                                action.actionPerformed(anActionEvent);
+                                Thread.sleep(1000);
+                                verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+
                             }
                         }
                     }
@@ -223,17 +216,15 @@ public class BuildActionTest extends ActionTest {
                                             (mock, context) -> {
                                                 doNothing().when(mock).start();
                                             })) {
-                                        try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                            funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
-                                            treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                            pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                            mockToolWindow(toolWindowManagerMockedStatic);
-                                            mockTelemetry(telemetryServiceMockedStatic);
-                                            action.actionPerformed(anActionEvent);
-                                            Thread.sleep(1000);
-                                            verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
-                                        }
+                                        treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                        pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                        mockToolWindow(toolWindowManagerMockedStatic);
+                                        mockTelemetry(telemetryServiceMockedStatic);
+                                        action.actionPerformed(anActionEvent);
+                                        Thread.sleep(1000);
+                                        verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+
                                     }
                                 }
                             }
@@ -263,16 +254,14 @@ public class BuildActionTest extends ActionTest {
                                 (mock, context) -> {
                                     doNothing().when(mock).start();
                                 })) {
-                                try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
 
-                                    funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
                                     treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
                                     pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
                                     yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenThrow(new IOException("error"));
                                     action.actionPerformed(anActionEvent);
                                     Thread.sleep(1000);
                                     verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
-                                }
+
 
                             }
                         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
@@ -136,6 +136,9 @@ public class BuildActionTest extends ActionTest {
                                 (mock, context) -> {
                                     doNothing().when(mock).start();
                                 })) {
+                            try(MockedStatic<FuncActionPipelineManager> funcActionPipelineManagerMockedStatic = mockStatic(FuncActionPipelineManager.class)) {
+
+                                funcActionPipelineManagerMockedStatic.when(() -> FuncActionPipelineManager.getInstance()).thenReturn(manager);
                                 treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
                                 pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
                                 when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
@@ -146,7 +149,8 @@ public class BuildActionTest extends ActionTest {
                                 action.actionPerformed(anActionEvent);
                                 Thread.sleep(1000);
 
-                                verify(buildFuncActionPipelineMockedConstruction.constructed().get(0), times(1)).start();
+                                verify(manager, times(1)).start(buildFuncActionPipelineMockedConstruction.constructed().get(0));
+                            }
                         }
                     }
                 }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/RunActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/RunActionTest.java
@@ -17,8 +17,8 @@ import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.knative.Constants;
 import com.redhat.devtools.intellij.knative.actions.func.RunAction;
 import com.redhat.devtools.intellij.knative.kn.Function;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.FuncActionTask;
-import com.redhat.devtools.intellij.knative.ui.brdWindow.runFuncWindowTab.RunFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab.RunFuncActionPipeline;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 
 import java.io.IOException;
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
-
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -59,7 +58,7 @@ public class RunActionTest extends ActionTest {
             treeHelperMockedStatic.when(() -> TreeHelper.getKn(any(Project.class))).thenReturn(kn);
             action.actionPerformed(anActionEvent);
             Thread.sleep(1000);
-            verify(kn, times(0)).runFunc(anyString(), any(), any());
+            verify(kn, times(0)).runFunc(anyString(), any(), any(), any());
         }
     }
 

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/RunActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/RunActionTest.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.knative.Constants;
 import com.redhat.devtools.intellij.knative.actions.func.RunAction;
 import com.redhat.devtools.intellij.knative.kn.Function;
 import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.FuncActionTask;
+import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.IFuncActionPipeline;
 import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.runFuncWindowTab.RunFuncActionPipeline;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
 
@@ -73,11 +74,11 @@ public class RunActionTest extends ActionTest {
                         (mock, context) -> {
                             doNothing().when(mock).start();
                 })) {
+                    when(manager.start(any(IFuncActionPipeline.class))).thenReturn(true);
                     treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
                     action.actionPerformed(anActionEvent);
                     Thread.sleep(1000);
-
-                    verify(runFuncActionPipelineMockedConstruction.constructed().get(0), times(1)).start();
+                    verify(manager, times(1)).start(runFuncActionPipelineMockedConstruction.constructed().get(0));
                }
             }
         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -12,8 +12,10 @@ package com.redhat.devtools.intellij.knative.kn;
 
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.terminal.TerminalExecutionConsole;
+import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
 import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.BaseTest;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
@@ -415,11 +417,12 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_RegistryIsInsertedButNoImage_BuildIsCalled() throws IOException {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
+        java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction = mock(java.util.function.Function.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "", terminalExecutionConsole, processListener);
+            kn.buildFunc("path", "registry", "", terminalExecutionConsole, processHandlerFunction, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
-                            any(TerminalExecutionConsole.class), any(ProcessListener.class), anyString(),
+                            any(TerminalExecutionConsole.class), any(java.util.function.Function.class), any(ProcessListener.class), anyString(),
                             eq("build"), eq("-r"), eq("registry"), eq("-p"), eq("path"),
                             eq("-v")));
         }
@@ -429,11 +432,12 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_ImageIsInserted_BuildIsCalled() throws IOException {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
+        java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction = mock(java.util.function.Function.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "image", terminalExecutionConsole, processListener);
+            kn.buildFunc("path", "registry", "image", terminalExecutionConsole, processHandlerFunction, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
-                            any(TerminalExecutionConsole.class), any(ProcessListener.class), anyString(),
+                            any(TerminalExecutionConsole.class), any(java.util.function.Function.class), any(ProcessListener.class), anyString(),
                             eq("build"), eq("-i"), eq("image"), eq("-p"), eq("path"),
                             eq("-v")));
         }
@@ -443,7 +447,7 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_ClientFails_Throws() {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             execHelperMockedStatic.when(() -> ExecHelper.executeWithTerminal(any(), anyString())).thenThrow(new IOException("error"));
-            kn.buildFunc("", "", "", null, null);
+            kn.buildFunc("", "", "", null, null, null);
         } catch (IOException e) {
             assertEquals("error", e.getLocalizedMessage());
         }
@@ -523,12 +527,13 @@ public class KnCliTest extends BaseTest {
     @Test
     public void RunFunc_PathIsInserted_RunIsCalled() throws IOException {
         ProcessListener processListener = mock(ProcessListener.class);
+        java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction = mock(java.util.function.Function.class);
         CommonTerminalExecutionConsole commonTerminalExecutionConsole = mock(CommonTerminalExecutionConsole.class);
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.runFunc("path", commonTerminalExecutionConsole, processListener);
+            kn.runFunc("path", commonTerminalExecutionConsole, processHandlerFunction, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
-                            any(CommonTerminalExecutionConsole.class), any(ProcessListener.class), anyString(), eq("run"), eq("-p"), eq("path")));
+                            any(CommonTerminalExecutionConsole.class), any(java.util.function.Function.class), any(ProcessListener.class), anyString(), eq("run"), eq("-p"), eq("path")));
         }
     }
 
@@ -536,7 +541,7 @@ public class KnCliTest extends BaseTest {
     public void RunFunc_ClientFails_Throws() {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             execHelperMockedStatic.when(() -> ExecHelper.executeWithTerminal(any(), anyString())).thenThrow(new IOException("error"));
-            kn.runFunc("", null, null);
+            kn.runFunc("", null, null, null);
         } catch (IOException e) {
             assertEquals("error", e.getLocalizedMessage());
         }


### PR DESCRIPTION
it resolves #174 

This patch adds 

- the stop action which allow to stop the execution of one task by clicking the button instead of killing the process from the terminal
- only one active run per function is allowed. So if a function is already running the user is informed and asked if he wants to stop the current executing process and start a new one

![stop-task](https://user-images.githubusercontent.com/49404737/171410467-c5762e52-0bd3-42f9-931c-4a30e08556bd.gif)

