### PR TITLE
chore: bump knative-client to 5.12.2 (#179)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ runIdeForUiTests {
 }
 
 dependencies {
-    compile 'io.fabric8:knative-client:5.7.4'
+    compile 'io.fabric8:knative-client:5.12.2'
     compile 'com.redhat.devtools.intellij:intellij-common:1.7.0'
     testCompile 'org.mockito:mockito-inline:3.8.0'
     compile 'com.squareup.okio:okio:1.15.0'


### PR DESCRIPTION
it resolves #179 

This needs to be merged before the next release as some actions do not work properly otherwise. Mainly those that leverage watches (e.g undeploy)