### PR TITLE
fix: prevent NPE when refresh action is executed (#171)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/RefreshAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/RefreshAction.java
@@ -58,14 +58,11 @@ public class RefreshAction extends StructureTreeAction {
                     .send();
             return;
         }
-        Object node = getElement(selected);
-        if (Constants.TOOLBAR_PLACE.equals(anActionEvent.getPlace())) {
-            structure.fireModified(structure.getRootElement());
-        } else {
+        Object node = Constants.TOOLBAR_PLACE.equals(anActionEvent.getPlace()) ? structure.getRootElement() : getElement(selected);
+        if (node != null) {
             structure.fireModified(node);
+            sendTelemetry(telemetry, node);
         }
-        sendTelemetry(telemetry, node);
-
     }
 
     private void sendTelemetry(TelemetryMessageBuilder.ActionMessage telemetry, Object node) {

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/RefreshActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/RefreshActionTest.java
@@ -57,9 +57,10 @@ public class RefreshActionTest extends ActionTest {
         AnAction action = new RefreshAction();
         AnActionEvent anActionEvent = createRefreshActionEvent(knTreeStructure);
         when(anActionEvent.getPlace()).thenReturn(Constants.TOOLBAR_PLACE);
-
+        when(knTreeStructure.getRootElement()).thenReturn(knRootNode);
         action.actionPerformed(anActionEvent);
-        verify(knTreeStructure).fireModified(any());
+        verify(knTreeStructure).getRootElement();
+        verify(knTreeStructure).fireModified(knRootNode);
     }
 
     @Test


### PR DESCRIPTION
It resolves #171 . I wasn't able to replicate it but looking at the code this should prevent the NPE faced by Gunjan