### PR TITLE
chore: bump func cli to 0.25.0

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -393,7 +393,7 @@ public class KnCli implements Kn {
     public void runFunc(String path, ConsoleView terminalExecutionConsole,
                         java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
                         ProcessListener processListener) throws IOException {
-        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processHandlerFunction, processListener, funcCommand, "run", "-p", path);
+        ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processHandlerFunction, processListener, funcCommand, "run", "-p", path, "-b=false");
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/listener/KnFileListener.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/listener/KnFileListener.java
@@ -41,7 +41,7 @@ public class KnFileListener implements AsyncFileListener {
     public @Nullable ChangeApplier prepareChange(@NotNull List<? extends VFileEvent> events) {
         events.forEach(event -> {
             if (event instanceof VFileContentChangeEvent) {
-                if (new File(event.getPath()).getName().equalsIgnoreCase("func.yaml")) {
+                if (isFuncYaml(event.getPath()) || isHiddenFileOrFolder(event.getPath())) {
                     return;
                 }
                 Date editDate = ((VFileContentChangeEvent) event).getModificationStamp() > 0 ? new Date() : null;
@@ -53,5 +53,20 @@ public class KnFileListener implements AsyncFileListener {
             }
         });
         return null;
+    }
+
+    private boolean isFuncYaml(String path) {
+        return new File(path).getName().equalsIgnoreCase("func.yaml");
+    }
+
+    private boolean isHiddenFileOrFolder(String path) {
+        File file = new File(path);
+        while(file != null) {
+            if (file.isHidden()) {
+                return true;
+            }
+            file = file.getParentFile();
+        }
+        return false;
     }
 }

--- a/src/main/resources/func.json
+++ b/src/main/resources/func.json
@@ -1,30 +1,30 @@
 {
   "tools": {
     "func": {
-      "version": "0.24.0",
+      "version": "0.25.0",
       "versionCmd": "version",
       "versionExtractRegExp": "v(\\d+[\\.\\d+]*)",
-      "versionMatchRegExpr": "0.24.0",
+      "versionMatchRegExpr": "0.25.0",
       "baseDir": "$HOME/.knative",
       "silentMode": true,
       "platforms": {
         "win": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.24.0/func_windows_amd64.exe",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_windows_amd64.exe",
           "cmdFileName": "func_windows_amd64.exe",
           "dlFileName": "func_windows_amd64.exe"
         },
         "osx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.24.0/func_darwin_amd64",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_darwin_amd64",
           "cmdFileName": "func_darwin_amd64",
           "dlFileName": "func_darwin_amd64"
         },
         "osx-arm64": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.24.0/func_darwin_arm64",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_darwin_arm64",
           "cmdFileName": "func_darwin_arm64",
           "dlFileName": "func_darwin_arm64"
         },
         "lnx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.24.0/func_linux_amd64",
+          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.25.0/func_linux_amd64",
           "cmdFileName": "func_linux_amd64",
           "dlFileName": "func_linux_amd64"
         }


### PR DESCRIPTION
it resolves #198 

Everything works fine. Only 2 issues found and fixed.
1) The run action now comes with the build flag which is set to `auto` by default. Because of our tool window that shows each step in a separate node i set it to false
2) When building a function, a new file is updated within the project `.func/build` so the file listener is always triggered for no reason and the plugin never skipped the build step