### PR TITLE
feat: add support for on-cluster build (#200)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def versionsMap = ['IU-2021.1':'211.6693.108', 'IU-2021.2':'212.4746.57', 'IU-20
 intellij {
     version = ideaVersion
     pluginName = 'Knative by Red Hat'
-    plugins = ['terminal', 'yaml', 'com.intellij.kubernetes:' + versionsMap[ideaVersion], 'com.redhat.devtools.intellij.telemetry:0.0.3.33', 'com.redhat.devtools.intellij.kubernetes:0.3.0.83']
+    plugins = ['terminal', 'yaml', 'github', 'com.intellij.kubernetes:' + versionsMap[ideaVersion], 'com.redhat.devtools.intellij.telemetry:0.0.3.33', 'com.redhat.devtools.intellij.kubernetes:0.3.0.83']
     updateSinceUntilBuild = false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ runIdeForUiTests {
 
 dependencies {
     compile 'io.fabric8:knative-client:5.12.2'
-    compile 'com.redhat.devtools.intellij:intellij-common:1.7.1'
+    compile 'com.redhat.devtools.intellij:intellij-common:1.8.0-SNAPSHOT'
     testCompile 'org.mockito:mockito-inline:3.8.0'
     compile 'com.squareup.okio:okio:1.15.0'
     // telemetry contributes annotations 13.0.0, so we need to declare newer version

--- a/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/Constants.java
@@ -64,4 +64,6 @@ public class Constants {
 
     public static final Color borderSearchFieldColor = JBColor.namedColor("Plugins.SearchField.borderColor", new JBColor(0xC5C5C5, 0x515151));
 
+    public static final String GIT_PLUGIN_ID = "org.jetbrains.plugins.github";
+
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
@@ -23,20 +23,22 @@ import com.intellij.openapi.ui.InputValidator;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Pair;
 import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
+import com.redhat.devtools.intellij.common.ui.InputDialogWithCheckbox;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.knative.actions.KnAction;
+import com.redhat.devtools.intellij.knative.func.FuncActionPipelineBuilder;
+import com.redhat.devtools.intellij.knative.func.FuncActionTask;
+import com.redhat.devtools.intellij.knative.func.IFuncActionPipeline;
 import com.redhat.devtools.intellij.knative.kn.Function;
 import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
-import com.redhat.devtools.intellij.knative.func.FuncActionTask;
-import com.redhat.devtools.intellij.knative.func.FuncActionPipelineBuilder;
-import com.redhat.devtools.intellij.knative.func.IFuncActionPipeline;
 import com.redhat.devtools.intellij.knative.utils.TreeHelper;
+import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,8 +49,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static com.intellij.openapi.ui.Messages.CANCEL_BUTTON;
-import static com.intellij.openapi.ui.Messages.OK_BUTTON;
 import static com.redhat.devtools.intellij.knative.Constants.NOTIFICATION_ID;
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.NAME_PREFIX_BUILD_DEPLOY;
 import static com.redhat.devtools.intellij.knative.telemetry.TelemetryService.PROP_CALLER_ACTION;
@@ -73,17 +73,11 @@ public class BuildAction extends KnAction {
         TelemetryMessageBuilder.ActionMessage telemetry = createTelemetryBuild();
         telemetry.property(PROP_CALLER_ACTION, buildStepHandler.getPipeline().getActionName());
         BuildAction buildAction = (BuildAction) ActionManager.getInstance().getAction(ID);
-        String image = function.getImage(), registry = "";
-        if (Strings.isNullOrEmpty(image)) {
-            Pair<String, String> registryAndImage = UIHelper.executeInUI(() -> buildAction.confirmAndGetRegistryImage(project, function, knCli, telemetry));
-            if (registryAndImage == null) {
-                return;
-            }
-            registry = registryAndImage.getFirst();
-            image = registryAndImage.getSecond();
+        ImageRegistryModel model = new ImageRegistryModel(function.getImage(), "");
+        if (Strings.isNullOrEmpty(model.getImage())) {
+            model = UIHelper.executeInUI(() -> buildAction.confirmAndGetRegistryImage(project, function, knCli, false, telemetry));
         }
-        buildAction.doExecuteAction(project, function, registry,
-                image, knCli, buildStepHandler, telemetry);
+        buildAction.doExecuteAction(project, function, model, knCli, buildStepHandler, telemetry);
     }
 
     @Override
@@ -93,36 +87,33 @@ public class BuildAction extends KnAction {
         TelemetryMessageBuilder.ActionMessage telemetry = createTelemetry();
         Project project = getEventProject(anActionEvent);
 
-        Pair<String, String> registryAndImage = confirmAndGetRegistryImage(project, function, knCli, telemetry);
-        if (registryAndImage == null) {
+        ImageRegistryModel model = confirmAndGetRegistryImage(project, function, knCli, false, telemetry);
+        if (model == null || !model.isValid()) {
             return;
         }
-
         IFuncActionPipeline buildPipeline = new FuncActionPipelineBuilder()
                 .createBuildPipeline(project, function)
                 .withBuildTask((task) ->
-                        ExecHelper.submit(() -> doExecuteAction(project, function, registryAndImage.getFirst(),
-                                registryAndImage.getSecond(), knCli, task, telemetry))
+                        ExecHelper.submit(() -> doExecuteAction(project, function, model, knCli, task, telemetry))
                 )
                 .build();
         knCli.getFuncActionPipelineManager().start(buildPipeline);
     }
 
-    protected Pair<String, String> confirmAndGetRegistryImage(Project project, Function function, Kn knCli, TelemetryMessageBuilder.ActionMessage telemetry) {
+    protected ImageRegistryModel confirmAndGetRegistryImage(Project project, Function function, Kn knCli, boolean forceAskImageToUser, TelemetryMessageBuilder.ActionMessage telemetry) {
         String namespace = knCli.getNamespace();
         if (!isLocalFunction(function, namespace, telemetry)) {
             return null;
         }
 
-        Pair<String, String> registryAndImage = getRegistryAndImage(function, knCli, telemetry);
-        if (registryAndImage == null) {
+        ImageRegistryModel model = getRegistryAndImage(function, knCli, forceAskImageToUser, telemetry);
+        if (model == null || !model.isValid()) {
             return null;
         }
-
         if (!isExecutionConfirmed(project, function, namespace, telemetry)) {
             return null;
         }
-        return registryAndImage;
+        return model;
     }
 
     private boolean isLocalFunction(Function function, String namespace, TelemetryMessageBuilder.ActionMessage telemetry) {
@@ -137,20 +128,13 @@ public class BuildAction extends KnAction {
         return true;
     }
 
-    private Pair<String, String> getRegistryAndImage(Function function, Kn knCli, TelemetryMessageBuilder.ActionMessage telemetry) {
-        Pair<String, String> dataToDeploy = getDataToDeploy(Paths.get(function.getLocalPath()), knCli);
-        String registry = dataToDeploy.getFirst();
-        String image = dataToDeploy.getSecond();
-        if (Strings.isNullOrEmpty(image) && Strings.isNullOrEmpty(registry)) {
+    protected ImageRegistryModel getRegistryAndImage(Function function, Kn knCli, boolean forceAskImageToUser, TelemetryMessageBuilder.ActionMessage telemetry) {
+        ImageRegistryModel dataToDeploy = getDataToDeploy(Paths.get(function.getLocalPath()), knCli);
+        String registry = dataToDeploy.getRegistry();
+        String image = dataToDeploy.getImage();
+        if (forceAskImageToUser || (Strings.isNullOrEmpty(image) && Strings.isNullOrEmpty(registry))) {
             // ask input to user
-            image = getImageFromUser(function.getName());
-            if (image.isEmpty()) {
-                telemetry
-                        .result(anonymizeResource(function.getName(), knCli.getNamespace(), "No image name or registry has been added."))
-                        .send();
-                return null;
-            }
-            return Pair.create(registry, image);
+            return getImageFromUser(function.getName());
         }
         return dataToDeploy;
     }
@@ -165,7 +149,7 @@ public class BuildAction extends KnAction {
         return true;
     }
 
-    protected void doExecuteAction(Project project, Function function, String registry, String image,
+    protected void doExecuteAction(Project project, Function function, ImageRegistryModel model,
                                    Kn knCli, FuncActionTask task,
                                    TelemetryMessageBuilder.ActionMessage telemetry) {
         String name = function.getName();
@@ -173,7 +157,7 @@ public class BuildAction extends KnAction {
         String localPathFunc = function.getLocalPath();
         try {
             function.setBuilding(true);
-            doExecute(task, knCli, namespace, localPathFunc, registry, image);
+            doExecute(task, knCli, namespace, localPathFunc, model);
             telemetry
                     .result(anonymizeResource(name, namespace, getSuccessMessage(namespace, name)))
                     .send();
@@ -191,22 +175,27 @@ public class BuildAction extends KnAction {
         }
     }
 
-    protected void doExecute(FuncActionTask task, Kn knCli, String namespace, String localPathFunc, String registry, String image) throws IOException {
+    protected void doExecute(FuncActionTask task, Kn knCli, String namespace, String localPathFunc, ImageRegistryModel model) throws IOException {
         ConsoleView terminalExecutionConsole = task != null ? task.getTerminalExecutionConsole() : null;
         java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction = task != null ? task.getProcessHandlerFunction() : null;
         ProcessListener processListener = task != null ? task.getProcessListener() : null;
-        knCli.buildFunc(localPathFunc, registry, image, terminalExecutionConsole, processHandlerFunction, processListener);
+        knCli.buildFunc(localPathFunc, model, terminalExecutionConsole, processHandlerFunction, processListener);
     }
 
     protected boolean isActionConfirmed(Project project, String name, String funcNamespace, String activeNamespace) {
         return true;
     }
 
-    protected String getImageFromUser(String name) {
+    protected ImageRegistryModel getImageFromUser(String name) {
         String defaultUsername = System.getProperty("user.name");
         String defaultImage = "quay.io/" + defaultUsername + "/" + name + ":latest";
-        Messages.InputDialog dialog = new Messages.InputDialog(null, "Provide full image name in the form [registry]/[namespace]/[name]:[tag] (e.g quay.io/boson/image:latest)",
-                "Build Function " + name, null, defaultImage,
+        InputDialogWithCheckbox dialog = new InputDialogWithCheckbox("Provide full image name in the form [registry]/[namespace]/[name]:[tag] (e.g quay.io/boson/image:latest)",
+                "Build Function " + name,
+                "Autodiscovery an internal registry and use it to deploy",
+                false,
+                true,
+                null,
+                defaultImage,
                 new InputValidator() {
                     @Override
                     public boolean checkInput(String inputString) {
@@ -217,27 +206,31 @@ public class BuildAction extends KnAction {
                     public boolean canClose(String inputString) {
                         return true;
                     }
-                },
-                new String[]{OK_BUTTON, CANCEL_BUTTON},
-                0, null);
+                });
+        dialog.setDisableTextPanelWithCheckbox();
         dialog.show();
         if (!dialog.isOK()) {
-            return "";
+            return null;
         }
-        return dialog.getInputString();
+        if (dialog.isChecked()) {
+            ImageRegistryModel model = new ImageRegistryModel();
+            model.setAutoDiscovery();
+            return model;
+        }
+        return new ImageRegistryModel(dialog.getInputString(), "");
     }
 
-    protected Pair<String, String> getDataToDeploy(Path root, Kn kncli) {
+    protected ImageRegistryModel getDataToDeploy(Path root, Kn kncli) {
         try {
             URL funcFileURL = kncli.getFuncFileURL(root);
             String content = YAMLHelper.JSONToYAML(YAMLHelper.URLToJSON(funcFileURL));
             String registry = YAMLHelper.getStringValueFromYAML(content, new String[]{"registry"});
             String image = YAMLHelper.getStringValueFromYAML(content, new String[]{"image"});
-            return Pair.create(registry, image);
+            return new ImageRegistryModel(image, registry);
         } catch(IOException e) {
             logger.warn(e.getLocalizedMessage(), e);
         }
-        return Pair.empty();
+        return new ImageRegistryModel();
     }
 
     protected TelemetryMessageBuilder.ActionMessage createTelemetry() {

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/BuildAction.java
@@ -189,9 +189,9 @@ public class BuildAction extends KnAction {
     protected ImageRegistryModel getImageFromUser(String name) {
         String defaultUsername = System.getProperty("user.name");
         String defaultImage = "quay.io/" + defaultUsername + "/" + name + ":latest";
-        InputDialogWithCheckbox dialog = new InputDialogWithCheckbox("Provide full image name in the form [registry]/[namespace]/[name]:[tag] (e.g quay.io/boson/image:latest)",
+        InputDialogWithCheckbox dialog = new InputDialogWithCheckbox("Provide full image name in the form registry/namespace/name:[tag] (e.g quay.io/boson/image:latest)",
                 "Build Function " + name,
-                "Autodiscovery an internal registry and use it to deploy",
+                "Auto discover an internal registry and use it to deploy",
                 false,
                 true,
                 null,

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
@@ -45,7 +45,7 @@ public class OnClusterBuildAction extends DeployAction {
         ParentableNode node = getElement(selected);
         Function function = ((KnFunctionNode) node).getFunction();
         TelemetryMessageBuilder.ActionMessage telemetry = createTelemetry();
-        Project project = getEventProject(anActionEvent);
+        Project project = anActionEvent.getProject();
 
         String gitRepo = getRepoUrl(project);
         if (gitRepo == null) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions.func;
+
+import com.google.common.base.Strings;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.intellij.common.utils.ExecHelper;
+import com.redhat.devtools.intellij.knative.func.FuncActionPipelineBuilder;
+import com.redhat.devtools.intellij.knative.func.FuncActionTask;
+import com.redhat.devtools.intellij.knative.func.IFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.kn.Function;
+import com.redhat.devtools.intellij.knative.kn.Kn;
+import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
+import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
+import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.tree.TreePath;
+import java.io.IOException;
+
+import static com.intellij.openapi.ui.Messages.showInputDialog;
+import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
+
+public class OnClusterBuildAction extends DeployAction {
+
+    private static final Logger logger = LoggerFactory.getLogger(OnClusterBuildAction.class);
+
+    public OnClusterBuildAction() {
+        super();
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent, TreePath path, Object selected, Kn knCli) {
+        ParentableNode node = getElement(selected);
+        Function function = ((KnFunctionNode) node).getFunction();
+        TelemetryMessageBuilder.ActionMessage telemetry = createTelemetry();
+        Project project = getEventProject(anActionEvent);
+
+        String gitRepo = getRepoUrl(project);
+        if (gitRepo == null) {
+            return;
+        }
+
+        ImageRegistryModel model = confirmAndGetRegistryImage(project, function, knCli, true, telemetry);
+        if (model == null || !model.isValid()) {
+            return;
+        }
+        if (!Strings.isNullOrEmpty(model.getImage())) {
+            function.setImage(model.getImage());
+        }
+
+        IFuncActionPipeline deployPipeline = new FuncActionPipelineBuilder()
+                .createDeployPipeline(project, function)
+                .withTask("deployFunc", (task) -> doDeploy(node.getName(), knCli, task, gitRepo,
+                        model, telemetry))
+                .build();
+        knCli.getFuncActionPipelineManager().start(deployPipeline);
+    }
+
+    private String getRepoUrl(Project project) {
+        String message = "Repo url to push the code to be built";
+
+        return showInputDialog(project,
+                message,
+                "On-Cluster Build",
+                null);
+    }
+
+    private void doDeploy(String name, Kn knCli, FuncActionTask funcActionTask, String repo, ImageRegistryModel model, TelemetryMessageBuilder.ActionMessage telemetry) {
+        ExecHelper.submit(() -> {
+            String namespace = knCli.getNamespace();
+            try {
+                knCli.onClusterBuildFunc(namespace, funcActionTask.getFunction().getLocalPath(), repo, model,
+                        funcActionTask.getTerminalExecutionConsole(), funcActionTask.getProcessListener());
+                telemetry
+                        .result(anonymizeResource(name, knCli.getNamespace(), getSuccessMessage(namespace, name)))
+                        .send();
+            } catch (IOException e) {
+                logger.warn(e.getLocalizedMessage(), e);
+                telemetry
+                        .error(anonymizeResource(name, namespace, e.getLocalizedMessage()))
+                        .send();
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
@@ -69,7 +69,7 @@ public class OnClusterBuildAction extends DeployAction {
     }
 
     private String getRepoUrl(Project project) {
-        String message = "Repo url to push the code to be built";
+        String message = "Git repo url to pull the code from to be built";
 
         return showInputDialog(project,
                 message,

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
@@ -21,6 +21,7 @@ import com.redhat.devtools.intellij.knative.kn.Function;
 import com.redhat.devtools.intellij.knative.kn.Kn;
 import com.redhat.devtools.intellij.knative.tree.KnFunctionNode;
 import com.redhat.devtools.intellij.knative.tree.ParentableNode;
+import com.redhat.devtools.intellij.knative.utils.FuncUtils;
 import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import org.slf4j.Logger;
@@ -93,6 +94,16 @@ public class OnClusterBuildAction extends DeployAction {
                         .send();
             }
         });
+    }
+
+    @Override
+    public boolean isVisible(Object selected) {
+        boolean visible = super.isVisible(selected);
+        if (visible) {
+            Kn kn = ((KnFunctionNode) selected).getRootNode().getKn();
+            return FuncUtils.isTektonReady(kn);
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
@@ -11,7 +11,9 @@
 package com.redhat.devtools.intellij.knative.actions.func;
 
 import com.google.common.base.Strings;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.knative.func.FuncActionPipelineBuilder;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import javax.swing.tree.TreePath;
 import java.io.IOException;
 
+import static com.redhat.devtools.intellij.knative.Constants.GIT_PLUGIN_ID;
 import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
 
 public class OnClusterBuildAction extends DeployAction {
@@ -114,7 +117,8 @@ public class OnClusterBuildAction extends DeployAction {
         boolean visible = super.isVisible(selected);
         if (visible) {
             Kn kn = ((KnFunctionNode) selected).getRootNode().getKn();
-            return FuncUtils.isTektonReady(kn);
+            PluginId gitPluginId = PluginId.findId(GIT_PLUGIN_ID);
+            return gitPluginId != null && !PluginManagerCore.isDisabled(gitPluginId) && FuncUtils.isTektonReady(kn);
         }
         return false;
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/func/OnClusterBuildAction.java
@@ -62,7 +62,7 @@ public class OnClusterBuildAction extends DeployAction {
 
         IFuncActionPipeline deployPipeline = new FuncActionPipelineBuilder()
                 .createDeployPipeline(project, function)
-                .withTask("deployFunc", (task) -> doDeploy(node.getName(), knCli, task, gitRepo,
+                .withTask("onClusterBuildFunc", (task) -> doDeploy(node.getName(), knCli, task, gitRepo,
                         model, telemetry))
                 .build();
         knCli.getFuncActionPipelineManager().start(deployPipeline);

--- a/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/StopFunctionTaskAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/actions/toolbar/StopFunctionTaskAction.java
@@ -13,6 +13,8 @@ package com.redhat.devtools.intellij.knative.actions.toolbar;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
+import com.redhat.devtools.intellij.knative.func.DeployFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.func.FuncActionTask;
 import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.BuildRunDeployFuncPanel;
 import com.redhat.devtools.intellij.knative.func.IFuncAction;
 import org.jetbrains.annotations.NotNull;
@@ -40,6 +42,24 @@ public class StopFunctionTaskAction extends DumbAwareAction {
     @Override
     public void update(@NotNull AnActionEvent e) {
         IFuncAction funcAction = panel.getSelectedFuncActionNode();
-        e.getPresentation().setEnabled(funcAction != null && !funcAction.isFinished());
+        e.getPresentation().setEnabled(shouldBeEnabled(funcAction));
+    }
+
+    private boolean shouldBeEnabled(IFuncAction funcAction) {
+        if (funcAction == null || funcAction.isFinished()) {
+            return false;
+        }
+
+        if (funcAction instanceof FuncActionTask) {
+            return !((FuncActionTask) funcAction).getActionName()
+                    .equalsIgnoreCase("onClusterBuildFunc");
+        }
+
+        if (funcAction instanceof DeployFuncActionPipeline) {
+            return !((DeployFuncActionPipeline) funcAction).getRunningStep().getActionName()
+                    .equalsIgnoreCase("onClusterBuildFunc");
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -34,9 +34,18 @@ import java.util.Map;
 public interface Kn {
 
     /**
+     * Check if the cluster is Tekton serving aware.
+     *
+     * @return true if Tekton is installed on cluster false otherwise
+     * @throws IOException if communication encountered an error
+     */
+    boolean isTektonAware() throws IOException;
+
+    /**
      * Check if the cluster is Knative serving aware.
      *
      * @return true if Knative Serving is installed on cluster false otherwise
+     * @throws IOException if communication encountered an error
      */
     boolean isKnativeServingAware() throws IOException;
 
@@ -44,6 +53,7 @@ public interface Kn {
      * Check if the cluster is Knative eventing aware.
      *
      * @return true if Knative Eventing is installed on cluster false otherwise
+     * @throws IOException if communication encountered an error
      */
     boolean isKnativeEventingAware() throws IOException;
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -17,6 +17,7 @@ import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.func.FuncActionPipelineManager;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
+import com.redhat.devtools.intellij.knative.utils.model.GitRepoModel;
 import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import com.redhat.devtools.intellij.knative.ui.repository.Repository;
@@ -256,7 +257,7 @@ public interface Kn {
      * @param processListener
      * @throws IOException if communication errored
      */
-    void onClusterBuildFunc(String namespace, String path, String repo, ImageRegistryModel model, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
+    void onClusterBuildFunc(String namespace, String path, GitRepoModel repoModel, ImageRegistryModel model, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
 
     /**
      * Invokes the Function by sending a test request to the currently running

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/Kn.java
@@ -17,6 +17,7 @@ import com.redhat.devtools.intellij.common.utils.CommonTerminalExecutionConsole;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.func.FuncActionPipelineManager;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
+import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import com.redhat.devtools.intellij.knative.ui.repository.Repository;
 import io.fabric8.kubernetes.client.Watch;
@@ -208,12 +209,13 @@ public interface Kn {
      * Build a function from path
      *
      * @param path     path where the source code is stored
-     * @param registry registry to use
-     * @param image    image name. This option takes precedence over registry which can be omitted
+     * @param model     image and registry model representing which registry or image to use.
+     *                  The image option takes precedence over registry which can be omitted.
+     *                  If the autoDiscovery is set to true no image or registry will be used and the cli will try to auto-detect it
      * @param terminalExecutionConsole terminal tab to be used to run the command. If null a new tab will be created
      * @throws IOException if communication errored
      */
-    void buildFunc(String path, String registry, String image, ConsoleView terminalExecutionConsole,
+    void buildFunc(String path, ImageRegistryModel model, ConsoleView terminalExecutionConsole,
                    java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction,
                    ProcessListener processListener) throws IOException;
 
@@ -222,13 +224,29 @@ public interface Kn {
      *
      * @param namespace namespace where to deploy
      * @param path      path where the source code is stored
-     * @param registry  registry to use
-     * @param image     image name. This option takes precedence over registry which can be omitted
+     * @param model     image and registry model representing which registry or image to use.
+     *                  The image option takes precedence over registry which can be omitted.
+     *                  If the autoDiscovery is set to true no image or registry will be used and the cli will try to auto-detect it
      * @param terminalExecutionConsole
      * @param processListener
      * @throws IOException if communication errored
      */
-    void deployFunc(String namespace, String path, String registry, String image, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
+    void deployFunc(String namespace, String path, ImageRegistryModel model, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
+
+    /**
+     * Start an on-cluster build
+     *
+     * @param namespace namespace where to deploy
+     * @param path      path where the source code is stored
+     * @param repo Repo url to push the code to be built
+     * @param terminalExecutionConsole
+     * @param model     image and registry model representing which registry or image to use.
+     *                  The image option takes precedence over registry which can be omitted.
+     *                  If the autoDiscovery is set to true no image or registry will be used and the cli will try to auto-detect it
+     * @param processListener
+     * @throws IOException if communication errored
+     */
+    void onClusterBuildFunc(String namespace, String path, String repo, ImageRegistryModel model, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException;
 
     /**
      * Invokes the Function by sending a test request to the currently running

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -174,7 +174,7 @@ public class KnCli implements Kn {
     @Override
     public List<Function> getFunctions() throws IOException {
         String json = ExecHelper.execute(funcCommand, envVars, "list", "-n", getNamespace(), "-o", "json");
-        if (json.startsWith("No functions found")) {
+        if (json.toLowerCase().startsWith("no functions found")) {
             return Collections.emptyList();
         }
         return getCustomCollection(json, Function.class);

--- a/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/kn/KnCli.java
@@ -324,7 +324,7 @@ public class KnCli implements Kn {
     public void deployFunc(String namespace, String path, ImageRegistryModel model, ConsoleView terminalExecutionConsole, ProcessListener processListener) throws IOException {
         String[] args = getBuildDeployArgs("deploy", namespace, path, model, "", true);
         List<String> argsList = new ArrayList<>(Arrays.asList(args));
-        argsList.addAll(Arrays.asList("-b", "disabled"));
+        argsList.addAll(Arrays.asList("--build", "false"));
         ExecHelper.executeWithTerminal(project, KNATIVE_TOOL_WINDOW_ID, envVars, terminalExecutionConsole, processListener, argsList.toArray(new String[0]));
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/BaseDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/BaseDialog.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.util.ui.JBUI;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.Border;
+import java.awt.Component;
+import java.awt.Dimension;
+
+import static com.redhat.devtools.intellij.knative.ui.UIConstants.ROW_DIMENSION;
+
+
+public abstract class BaseDialog extends DialogWrapper {
+
+    protected BaseDialog(@Nullable Project project, boolean canBeParent) {
+        super(project, canBeParent);
+    }
+
+    protected JPanel addComponentToContent(JPanel parent, JComponent componentLeft, JComponent componentCenter, JComponent componentRight, int top) {
+        JPanel panel = createFilledPanel(componentLeft, componentCenter, componentRight);
+        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        panel.setBorder(JBUI.Borders.empty(top, 0, 5, 0));
+        parent.add(panel);
+        return panel;
+    }
+
+    protected JPanel createFilledPanel(JComponent componentLeft, JComponent componentCenter, JComponent componentRight) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        if (componentLeft != null) {
+            componentLeft.setBorder(JBUI.Borders.emptyLeft(10));
+            componentLeft.setMinimumSize(new Dimension(120, 40));
+            componentLeft.setPreferredSize(new Dimension(120, 40));
+            componentLeft.setMaximumSize(new Dimension(120, 40));
+            panel.add(componentLeft);
+        }
+        if (componentCenter != null) {
+            componentCenter.setMaximumSize(ROW_DIMENSION);
+            panel.add(componentCenter);
+        }
+        if (componentRight != null) {
+            componentRight.setMaximumSize(new Dimension(150, 40));
+            panel.add(componentRight);
+        }
+        return panel;
+    }
+
+    protected JLabel createLabel(String text, String tooltip, Border border) {
+        JLabel label = new JLabel(text);
+        if (!tooltip.isEmpty()) {
+            label.setToolTipText(tooltip);
+        }
+        if (border != null) {
+            label.setBorder(border);
+        }
+        return label;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/GitDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/GitDialog.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.ui;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.TextFieldWithAutoCompletion;
+import com.intellij.ui.TextFieldWithAutoCompletionListProvider;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.Consumer;
+import com.intellij.util.ui.JBUI;
+import com.redhat.devtools.intellij.knative.utils.model.GitRepoModel;
+import git4idea.GitLocalBranch;
+import git4idea.GitUtil;
+import git4idea.branch.GitBranchesCollection;
+import git4idea.repo.GitRemote;
+import git4idea.repo.GitRepository;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.redhat.devtools.intellij.knative.ui.UIConstants.RED_BORDER_SHOW_ERROR;
+
+public class GitDialog extends BaseDialog {
+    private JPanel wrapperPanel, contentPanel, panelGitRepoError;
+    private JBScrollPane scrollPane;
+    private TextFieldWithAutoCompletion<GitRemote> txtRemotesWithAutoCompletion;
+    private TextFieldWithAutoCompletion<String> txtBranchesWithAutoCompletion;
+    private JLabel lblGitRepoError;
+    private Project project;
+    private Border originalBorder;
+    private List<GitRepository> gitRepositories;
+
+    public GitDialog(Project project, String title, String descriptionText) {
+        super(project, true);
+        this.project = project;
+        gitRepositories = GitUtil.getRepositoryManager(project).getRepositories();
+        setTitle(title);
+        buildStructure(descriptionText);
+        init();
+    }
+
+    private void buildStructure(String descriptionText) {
+        wrapperPanel = new JPanel(new BorderLayout());
+
+        contentPanel = new JPanel();
+        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+        fillContentPanel(descriptionText);
+
+
+        scrollPane = new JBScrollPane(contentPanel);
+        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.setBorder(JBUI.Borders.empty());
+
+        wrapperPanel.add(scrollPane, BorderLayout.CENTER);
+    }
+
+    private void fillContentPanel(String descriptionText) {
+        addTopDescription(descriptionText);
+        addRepoField();
+        addErrorRepo();
+        addBranchField();
+
+        JPanel panel = new JPanel(new BorderLayout());
+        contentPanel.add(panel);
+    }
+
+    private void addTopDescription(String descriptionText) {
+        JLabel topDescription = new JLabel(descriptionText);
+        topDescription.setBorder(JBUI.Borders.empty(10, 0, 10, 10));
+        addComponentToContent(contentPanel, null, topDescription, null, 5);
+    }
+
+    private void addRepoField() {
+        JLabel lblIDParam = createLabel("Repo:",
+                "The repository to use for building and deploying.",
+                null);
+
+        List<GitRemote> gitRemotes = !gitRepositories.isEmpty()
+                ? new ArrayList<>((gitRepositories.get(0).getRemotes()))
+                : Collections.emptyList();
+        txtRemotesWithAutoCompletion = createTextFieldAutoCompletion(
+                gitRemotes,
+                !gitRemotes.isEmpty() ? gitRemotes.get(0).getFirstUrl() : "",
+                (item) -> {
+                    if (panelGitRepoError.isVisible()) {
+                        panelGitRepoError.setVisible(false);
+                        txtRemotesWithAutoCompletion.setBorder(originalBorder);
+                    }
+                    return ((GitRemote)item).getFirstUrl();
+                },
+                null
+        );
+        originalBorder = txtRemotesWithAutoCompletion.getBorder();
+
+        addComponentToContent(contentPanel, lblIDParam, txtRemotesWithAutoCompletion, null, 0);
+    }
+
+    private void addErrorRepo() {
+
+        lblGitRepoError = new JLabel("Please provide a valid git repository");
+        lblGitRepoError.setForeground(JBColor.RED);
+
+        panelGitRepoError = new JPanel(new FlowLayout());
+        panelGitRepoError.add(lblGitRepoError);
+        panelGitRepoError.setAlignmentX(Component.LEFT_ALIGNMENT);
+        panelGitRepoError.setVisible(false);
+
+        contentPanel.add(panelGitRepoError);
+    }
+
+    private void addBranchField() {
+        JLabel lblBranchParam = createLabel("Branch:",
+                "The branch to use for building and deploying. If left empty, the main branch is used.",
+                null);
+
+        GitLocalBranch gitLocalBranch = gitRepositories.get(0).getCurrentBranch();
+        txtBranchesWithAutoCompletion = createTextFieldAutoCompletion(
+                new ArrayList(),
+                gitLocalBranch != null ? gitLocalBranch.getName() : "",
+                (item) -> (String) item,
+                () -> getBranchesAutoCompletion()
+        );
+        addComponentToContent(contentPanel, lblBranchParam, txtBranchesWithAutoCompletion, null, 5);
+    }
+
+    private <T> TextFieldWithAutoCompletion createTextFieldAutoCompletion(List<T> initialValues, String defaultValue, Function<Object, String> getLookupString, Supplier<List<LookupElement>> getLookupItems) {
+        return new TextFieldWithAutoCompletion(project,
+                new TextFieldWithAutoCompletionListProvider(initialValues) {
+                    @Override
+                    protected @NotNull String getLookupString(@NotNull Object item) {
+                        return getLookupString.apply(item);
+                    }
+
+                    @Override
+                    public void fillCompletionVariants(@NotNull CompletionParameters parameters, @NotNull String prefix, @NotNull CompletionResultSet result) {
+                        if (getLookupItems != null) {
+                            result.addAllElements(getLookupItems.get());
+                        }
+                        super.fillCompletionVariants(parameters, prefix, result);
+                    }
+                },
+                true,
+                defaultValue
+        ) {
+            @Override
+            protected EditorEx createEditor() {
+                EditorEx editor = super.createEditor();
+                CompoundBorder compoundBorder = BorderFactory.createCompoundBorder(new JTextField().getBorder(), JBUI.Borders.empty(7, 7, 3, 7));
+                editor.setBorder(compoundBorder);
+                editor.getContentSize().setSize(200, new JTextField().getHeight());
+                return editor;
+            }
+        };
+    }
+
+    private List<LookupElement> getBranchesAutoCompletion() {
+        String currentRemoteUrl = txtRemotesWithAutoCompletion.getText();
+        GitBranchesCollection gitBranchesCollection = gitRepositories.get(0).getBranches();
+        return gitBranchesCollection.getRemoteBranches().stream()
+                .filter(branch -> branch.getRemote().getFirstUrl().equalsIgnoreCase(currentRemoteUrl))
+                .map(branch -> LookupElementBuilder.create(branch, branch.getNameForRemoteOperations())).collect(Collectors.toList());
+    }
+
+    public static void main(String[] args) {
+        GitDialog dialog = new GitDialog(null, "", "");
+        dialog.pack();
+        dialog.show();
+        System.exit(0);
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        final JPanel panel = new JPanel(new BorderLayout());
+        panel.setMinimumSize(new Dimension(500, 200));
+        panel.add(wrapperPanel, BorderLayout.CENTER);
+        return panel;
+    }
+
+    @Override
+    protected void doOKAction() {
+        if (txtRemotesWithAutoCompletion.getText().isEmpty()) {
+            panelGitRepoError.setVisible(true);
+            txtRemotesWithAutoCompletion.setBorder(RED_BORDER_SHOW_ERROR);
+            contentPanel.invalidate();
+            return;
+        }
+        super.doOKAction();
+    }
+
+    public GitRepoModel getGitInfo() {
+        String repo = txtRemotesWithAutoCompletion.getText();
+        String branch = txtBranchesWithAutoCompletion.getText();
+        return new GitRepoModel(repo, branch);
+    }
+}
+

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/GitDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/GitDialog.java
@@ -110,13 +110,13 @@ public class GitDialog extends BaseDialog {
     private void addTopWarningMessage(String remote) {
         String message = "";
         if (gitRepository == null) {
-            message = "Your project is not a git repository. Please initialize it before to proceed building it on cluster.";
+            message = "This project is not a git repository. Please git initialise it and then proceed to build it on the cluster.";
         } else {
             List<GitFileStatus> gitFileStatuses = gitRepository.getStagingAreaHolder().getAllRecords();
             if (remote.isEmpty()) {
-                message = "Your local branch is not present remotely. Push it before to proceed building it on cluster";
+                message = "The local branch is not present remotely. Push it to remote and then proceed to build it on cluster";
             } else if (!gitFileStatuses.isEmpty()) {
-                message = "Your local branch contains some uncommitted changes. Push them before to proceed building it on cluster";
+                message = "The local branch contains some uncommitted changes. Push those changes and then proceed to build it on cluster";
             }
         }
         if (!message.isEmpty()) {
@@ -152,7 +152,7 @@ public class GitDialog extends BaseDialog {
 
     private void addRepoField(String remote) {
         JLabel lblIDParam = createLabel("Repo:",
-                "The repository to use for building and deploying.",
+                "Provide git repository with the function source code",
                 null);
 
         List<GitRemote> gitRemotes = gitRepository != null
@@ -190,7 +190,7 @@ public class GitDialog extends BaseDialog {
 
     private void addBranchField(String branch) {
         JLabel lblBranchParam = createLabel("Branch:",
-                "The branch to use for building and deploying. If left empty, the main branch is used.",
+                "Git revision to be used (branch, tag, commit). If left empty, the main branch is used.",
                 null);
 
         txtBranchesWithAutoCompletion = createTextFieldAutoCompletion(

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/UIConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/UIConstants.java
@@ -15,9 +15,11 @@ import com.intellij.ui.JBColor;
 import javax.swing.border.Border;
 import javax.swing.border.MatteBorder;
 import java.awt.Color;
+import java.awt.Dimension;
 
 public class UIConstants {
     public static final Color RED = new JBColor(new Color(229, 77, 4), new Color(229, 77, 4));
 
     public static final Border RED_BORDER_SHOW_ERROR = new MatteBorder(1, 1, 1, 1, RED);
+    public static final Dimension ROW_DIMENSION = new Dimension(Integer.MAX_VALUE, 40);
 }

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/invokeFunc/InvokeDialog.java
@@ -11,15 +11,14 @@
 package com.redhat.devtools.intellij.knative.ui.invokeFunc;
 
 import com.google.common.io.Files;
-import com.intellij.ide.ui.laf.darcula.ui.DarculaTextBorder;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
-import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.TextFieldWithAutoCompletion;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.ui.JBUI;
 import com.redhat.devtools.intellij.knative.kn.Function;
+import com.redhat.devtools.intellij.knative.ui.BaseDialog;
 import com.redhat.devtools.intellij.knative.utils.MimeTypes;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import org.jetbrains.annotations.Nullable;
@@ -40,7 +39,6 @@ import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
-import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.filechooser.FileSystemView;
@@ -48,13 +46,14 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.Insets;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class InvokeDialog extends DialogWrapper {
+import static com.redhat.devtools.intellij.knative.ui.UIConstants.ROW_DIMENSION;
+
+public class InvokeDialog extends BaseDialog {
     private final Logger logger = LoggerFactory.getLogger(InvokeDialog.class);
     private JPanel wrapperPanel, contentPanel, panelPath, panelNamespace, panelURL;
     private JBScrollPane scrollPane;
@@ -75,7 +74,7 @@ public class InvokeDialog extends DialogWrapper {
 
     private TitledBorder titledBorderInvokeSection;
 
-    private static final Dimension ROW_DIMENSION = new Dimension(Integer.MAX_VALUE, 40);
+
     private static final String AUTOMATICALLY_GENERATED_TEXT = "Automatically generated";
     private static final String TEXT_OPTION = "Text";
     private static final String FILE_OPTION = "File";
@@ -374,16 +373,7 @@ public class InvokeDialog extends DialogWrapper {
         wrapperPanel.add(panel, BorderLayout.NORTH);
     }
 
-    private JLabel createLabel(String text, String tooltip, Border border) {
-        JLabel label = new JLabel(text);
-        if (!tooltip.isEmpty()) {
-            label.setToolTipText(tooltip);
-        }
-        if (border != null) {
-            label.setBorder(border);
-        }
-        return label;
-    }
+
 
     private JPanel addGroupedComponentsToContent(String title, JCheckBox chkEnableComponent, JComponent componentCenter) {
         JPanel panel = new JPanel();
@@ -405,35 +395,6 @@ public class InvokeDialog extends DialogWrapper {
         chkEnableComponent.addItemListener(e -> componentCenter.setEnabled(chkEnableComponent.isSelected()));
         panel.setAlignmentX(Component.LEFT_ALIGNMENT);
         contentPanel.add(panel);
-        return panel;
-    }
-
-    private JPanel addComponentToContent(JPanel parent, JComponent componentLeft, JComponent componentCenter, JComponent componentRight, int top) {
-        JPanel panel = createFilledPanel(componentLeft, componentCenter, componentRight);
-        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        panel.setBorder(JBUI.Borders.empty(top, 0, 5, 0));
-        parent.add(panel);
-        return panel;
-    }
-
-    private JPanel createFilledPanel(JComponent componentLeft, JComponent componentCenter, JComponent componentRight) {
-        JPanel panel = new JPanel();
-        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
-        if (componentLeft != null) {
-            componentLeft.setBorder(JBUI.Borders.emptyLeft(10));
-            componentLeft.setMinimumSize(new Dimension(120, 40));
-            componentLeft.setPreferredSize(new Dimension(120, 40));
-            componentLeft.setMaximumSize(new Dimension(120, 40));
-            panel.add(componentLeft);
-        }
-        if (componentCenter != null) {
-            componentCenter.setMaximumSize(ROW_DIMENSION);
-            panel.add(componentCenter);
-        }
-        if (componentRight != null) {
-            componentRight.setMaximumSize(new Dimension(150, 40));
-            panel.add(componentRight);
-        }
         return panel;
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/FuncUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/FuncUtils.java
@@ -25,6 +25,26 @@ import java.util.concurrent.TimeoutException;
 
 public class FuncUtils {
 
+    public static boolean isTektonReady(Kn kn) {
+        try {
+            return isTektonAwareAsync(kn).get(500, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            return false;
+        }
+    }
+
+    private static CompletableFuture<Boolean> isTektonAwareAsync(Kn kn) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        ExecHelper.submit(() -> {
+            try {
+                result.complete(kn.isTektonAware());
+            } catch (IOException e) {
+                result.complete(false);
+            }
+        });
+        return result;
+    }
+
     public static boolean isKnativeReady(Kn kn) {
         try {
             return isKnServingAndEventingAwareAsync(kn).get(500, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/model/GitRepoModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/model/GitRepoModel.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils.model;
+
+import org.jetbrains.annotations.NotNull;
+
+public class GitRepoModel {
+
+    private final String repository;
+    private final String branch;
+
+    public GitRepoModel(@NotNull String repository) {
+        this(repository, "");
+    }
+
+    public GitRepoModel(@NotNull String repository, String branch) {
+        this.repository = repository;
+        this.branch = branch;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/knative/utils/model/ImageRegistryModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/utils/model/ImageRegistryModel.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils.model;
+
+public class ImageRegistryModel {
+    private String image, registry;
+    private boolean autoDiscovery;
+
+    public ImageRegistryModel(String image, String registry) {
+        this.image = image;
+        this.registry = registry;
+        this.autoDiscovery = false;
+    }
+
+    public ImageRegistryModel() {
+        this("", "");
+    }
+
+    public void setAutoDiscovery() {
+        this.image = "";
+        this.registry = "";
+        this.autoDiscovery = true;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public String getRegistry() {
+        return registry;
+    }
+
+    public boolean isAutoDiscovery() {
+        return autoDiscovery;
+    }
+
+    public boolean isValid() {
+        return !image.isEmpty()
+                || !registry.isEmpty()
+                || isAutoDiscovery();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,7 +59,7 @@
     <depends>org.jetbrains.plugins.terminal</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
-    <depends optional="true">org.jetbrains.plugins.github</depends>
+    <depends optional="true" config-file="">org.jetbrains.plugins.github</depends>
     <depends>com.redhat.devtools.intellij.telemetry</depends>
     <depends>com.redhat.devtools.intellij.kubernetes</depends>
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,7 @@
     <depends>org.jetbrains.plugins.terminal</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
+    <depends>org.jetbrains.plugins.github</depends>
     <depends>com.redhat.devtools.intellij.telemetry</depends>
     <depends>com.redhat.devtools.intellij.kubernetes</depends>
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,7 +59,7 @@
     <depends>org.jetbrains.plugins.terminal</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
-    <depends>org.jetbrains.plugins.github</depends>
+    <depends optional="true">org.jetbrains.plugins.github</depends>
     <depends>com.redhat.devtools.intellij.telemetry</depends>
     <depends>com.redhat.devtools.intellij.kubernetes</depends>
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -101,6 +101,9 @@
             <action id="com.redhat.devtools.intellij.knative.actions.func.DeployAction"
                     class="com.redhat.devtools.intellij.knative.actions.func.DeployAction"
                     text="Deploy"/>
+            <action id="com.redhat.devtools.intellij.knative.actions.func.OnClusterBuildAction"
+                    class="com.redhat.devtools.intellij.knative.actions.func.OnClusterBuildAction"
+                    text="On Cluster Build" />
             <action id="com.redhat.devtools.intellij.knative.actions.func.InvokeAction"
                     class="com.redhat.devtools.intellij.knative.actions.func.InvokeAction"
                     text="Invoke"/>

--- a/src/main/resources/func.json
+++ b/src/main/resources/func.json
@@ -1,30 +1,30 @@
 {
   "tools": {
     "func": {
-      "version": "0.26.0",
+      "version": "1.7.0",
       "versionCmd": "version",
       "versionExtractRegExp": "v(\\d+[\\.\\d+]*)",
-      "versionMatchRegExpr": "0.26.0",
+      "versionMatchRegExpr": "1.7.0",
       "baseDir": "$HOME/.knative",
       "silentMode": true,
       "platforms": {
         "win": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_windows_amd64.exe",
+          "url": "https://github.com/knative/func/releases/download/knative-v1.7.0/func_windows_amd64.exe",
           "cmdFileName": "func_windows_amd64.exe",
           "dlFileName": "func_windows_amd64.exe"
         },
         "osx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_darwin_amd64",
+          "url": "https://github.com/knative/func/releases/download/knative-v1.7.0/func_darwin_amd64",
           "cmdFileName": "func_darwin_amd64",
           "dlFileName": "func_darwin_amd64"
         },
         "osx-arm64": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_darwin_arm64",
+          "url": "https://github.com/knative/func/releases/download/knative-v1.7.0/func_darwin_arm64",
           "cmdFileName": "func_darwin_arm64",
           "dlFileName": "func_darwin_arm64"
         },
         "lnx": {
-          "url": "https://github.com/knative-sandbox/kn-plugin-func/releases/download/v0.26.0/func_linux_amd64",
+          "url": "https://github.com/knative/func/releases/download/knative-v1.7.0/func_linux_amd64",
           "cmdFileName": "func_linux_amd64",
           "dlFileName": "func_linux_amd64"
         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/BuildActionTest.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.redhat.devtools.intellij.common.ui.InputDialogWithCheckbox;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.knative.Constants;
@@ -84,7 +85,7 @@ public class BuildActionTest extends ActionTest {
                         mockToolWindow(toolWindowManagerMockedStatic);
                         mockTelemetry(telemetryServiceMockedStatic);
                         action.actionPerformed(anActionEvent);
-                        verify(kn, times(0)).buildFunc(anyString(), anyString(), anyString(), any(), any(), any());
+                        verify(kn, times(0)).buildFunc(anyString(), any(), any(), any(), any());
                     }
                 }
             }
@@ -160,10 +161,11 @@ public class BuildActionTest extends ActionTest {
         try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
                 try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
-                    try(MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                             (mock, context) -> {
                                 when(mock.isOK()).thenReturn(true);
                                 when(mock.getInputString()).thenReturn("image");
+                                when(mock.isChecked()).thenReturn(false);
                             })) {
                         try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
                             try (MockedConstruction<BuildFuncActionPipeline> buildFuncActionPipelineMockedConstruction = mockConstruction(BuildFuncActionPipeline.class,
@@ -205,10 +207,11 @@ public class BuildActionTest extends ActionTest {
                                 ((Runnable) invocation.getArguments()[0]).run();
                                 return 0;
                             });
-                            try (MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                            try (MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                                     (mock, context) -> {
                                         when(mock.isOK()).thenReturn(true);
                                         when(mock.getInputString()).thenReturn("image");
+                                        when(mock.isChecked()).thenReturn(false);
                                     })) {
                                 try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
                                     try (MockedConstruction<BuildFuncActionPipeline> buildFuncActionPipelineMockedConstruction = mockConstruction(BuildFuncActionPipeline.class,
@@ -243,10 +246,11 @@ public class BuildActionTest extends ActionTest {
         try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
                 try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
-                    try (MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                    try (MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                         (mock, context) -> {
                             when(mock.isOK()).thenReturn(true);
                             when(mock.getInputString()).thenReturn("image");
+                            when(mock.isChecked()).thenReturn(false);
                         })) {
                         try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
                             try(MockedConstruction<BuildFuncActionPipeline> buildFuncActionPipelineMockedConstruction = mockConstruction(BuildFuncActionPipeline.class,
@@ -285,10 +289,11 @@ public class BuildActionTest extends ActionTest {
                                     ((Runnable) invocation.getArguments()[0]).run();
                                     return 0;
                                 });
-                                try (MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                                try (MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                                         (mock, context) -> {
                                             when(mock.isOK()).thenReturn(true);
                                             when(mock.getInputString()).thenReturn("");
+                                            when(mock.isChecked()).thenReturn(false);
                                         })) {
 
                                     treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
@@ -300,7 +305,7 @@ public class BuildActionTest extends ActionTest {
                                     mockTelemetry(telemetryServiceMockedStatic);
                                     action.actionPerformed(anActionEvent);
                                     Thread.sleep(1000);
-                                    verify(kn, times(0)).buildFunc(eq("path"), eq(""), eq("image"), eq(null), eq(null), eq(null));
+                                    verify(kn, times(0)).buildFunc(eq("path"), eq(null), eq(null), eq(null), eq(null));
                                 }
                             }
                         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/DeployActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/DeployActionTest.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.redhat.devtools.intellij.common.ui.InputDialogWithCheckbox;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
 import com.redhat.devtools.intellij.knative.Constants;
 import com.redhat.devtools.intellij.knative.actions.func.DeployAction;
@@ -158,10 +159,11 @@ public class DeployActionTest extends ActionTest {
         try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
                 try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
-                    try(MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                             (mock, context) -> {
                                 when(mock.isOK()).thenReturn(true);
                                 when(mock.getInputString()).thenReturn("image");
+                                when(mock.isChecked()).thenReturn(false);
                             })) {
                         try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
                             try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
@@ -195,10 +197,11 @@ public class DeployActionTest extends ActionTest {
 
         try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
-                try(MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                         (mock, context) -> {
                             when(mock.isOK()).thenReturn(true);
                             when(mock.getInputString()).thenReturn("image");
+                            when(mock.isChecked()).thenReturn(false);
                         })) {
                     try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
                         try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
@@ -230,10 +233,11 @@ public class DeployActionTest extends ActionTest {
         try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
                 try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
-                    try(MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                             (mock, context) -> {
                                 when(mock.isOK()).thenReturn(true);
                                 when(mock.getInputString()).thenReturn("image");
+                                when(mock.isChecked()).thenReturn(false);
                             })) {
                         try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
                             try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
@@ -266,29 +270,31 @@ public class DeployActionTest extends ActionTest {
         try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
             try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
                 try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
-                    try(MockedConstruction<Messages.InputDialog> inputDialogMockedConstruction = mockConstruction(Messages.InputDialog.class,
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
                             (mock, context) -> {
                                 when(mock.isOK()).thenReturn(true);
                                 when(mock.getInputString()).thenReturn("");
+                                when(mock.isChecked()).thenReturn(false);
                             })) {
-                        try (MockedStatic<TelemetryService> telemetryServiceMockedStatic = mockStatic((TelemetryService.class))) {
-                            try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
-                                try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
-                                        (mock, context) -> {
-                                            doNothing().when(mock).start();
-                                        })) {
-                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
-                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
-                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
-                                    yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
-                                    yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
-                                    mockTelemetry(telemetryServiceMockedStatic);
-                                    action.actionPerformed(anActionEvent);
-                                    Thread.sleep(1000);
-                                    assertEquals(0, deployFuncActionPipelineMockedConstruction.constructed().size());
+                            try (MockedStatic<TelemetryService> telemetryServiceMockedStatic = mockStatic((TelemetryService.class))) {
+                                try (MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                                    try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                            (mock, context) -> {
+                                                doNothing().when(mock).start();
+                                            })) {
+                                        treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                        pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                        yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                        yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
+                                        yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
+                                        mockTelemetry(telemetryServiceMockedStatic);
+                                        action.actionPerformed(anActionEvent);
+                                        Thread.sleep(1000);
+                                        assertEquals(0, deployFuncActionPipelineMockedConstruction.constructed().size());
+                                    }
                                 }
                             }
-                        }
+
                     }
                 }
             }

--- a/src/test/java/com/redhat/devtools/intellij/knative/actions/OnClusterBuildActionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/actions/OnClusterBuildActionTest.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.actions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.redhat.devtools.intellij.common.ui.InputDialogWithCheckbox;
+import com.redhat.devtools.intellij.common.utils.YAMLHelper;
+import com.redhat.devtools.intellij.knative.Constants;
+import com.redhat.devtools.intellij.knative.actions.func.DeployAction;
+import com.redhat.devtools.intellij.knative.actions.func.OnClusterBuildAction;
+import com.redhat.devtools.intellij.knative.func.DeployFuncActionPipeline;
+import com.redhat.devtools.intellij.knative.func.FuncActionTask;
+import com.redhat.devtools.intellij.knative.kn.Function;
+import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
+import com.redhat.devtools.intellij.knative.utils.TreeHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import javax.swing.tree.TreePath;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+public class OnClusterBuildActionTest extends ActionTest {
+    private Function function;
+    private Path pathFuncFile;
+    private JsonNode jsonNode;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        function = mock(Function.class);
+        pathFuncFile = mock(Path.class);
+        jsonNode = mock(JsonNode.class);
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasNotLocalPath_DoNothing() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+        when(function.getLocalPath()).thenReturn("");
+
+        try (MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<TelemetryService> telemetryServiceMockedStatic = mockStatic((TelemetryService.class))) {
+                try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                    try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                        try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                (mock, context) -> {
+                                    doNothing().when(mock).start();
+                                })) {
+                            when(kn.getNamespace()).thenReturn("namespace");
+                            treeHelperMockedStatic.when(() -> TreeHelper.getKn(any(Project.class))).thenReturn(kn);
+                            messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                            mockTelemetry(telemetryServiceMockedStatic);
+                            action.actionPerformed(anActionEvent);
+                            Thread.sleep(1000);
+
+                            assertEquals(0, deployFuncActionPipelineMockedConstruction.constructed().size());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasLocalPathAndImageSpecified_DoDeploy() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+        try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
+                try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
+                    try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                        try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
+                                (mock, context) -> {
+                                    when(mock.isOK()).thenReturn(true);
+                                    when(mock.getInputString()).thenReturn("test");
+                                    when(mock.isChecked()).thenReturn(false);
+                                })) {
+                            try (MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                                try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                        (mock, context) -> {
+                                            doNothing().when(mock).start();
+                                        })) {
+                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                    when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("image: test");
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("test");
+                                    messagesMockedStatic.when(() -> Messages.showOkCancelDialog(any(Project.class), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.OK);
+                                    messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                                    action.actionPerformed(anActionEvent);
+                                    Thread.sleep(1000);
+                                    verify(manager, times(1)).start(deployFuncActionPipelineMockedConstruction.constructed().get(0));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasLocalPathAndUserSelectAutoDiscovery_DoDeploy() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+        try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
+                try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
+                    try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                        try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
+                                (mock, context) -> {
+                                    when(mock.isOK()).thenReturn(true);
+                                    when(mock.getInputString()).thenReturn("");
+                                    when(mock.isChecked()).thenReturn(true);
+                                })) {
+                            try (MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                                try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                        (mock, context) -> {
+                                            doNothing().when(mock).start();
+                                        })) {
+                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                    when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("registry: test");
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("test").thenReturn("");
+                                    messagesMockedStatic.when(() -> Messages.showOkCancelDialog(any(Project.class), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.OK);
+                                    messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                                    action.actionPerformed(anActionEvent);
+                                    Thread.sleep(1000);
+                                    verify(manager, times(1)).start(deployFuncActionPipelineMockedConstruction.constructed().get(0));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasLocalPathAndHasFuncFileWithoutRegistryAndImageSpecified_UIAskForImage() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+
+        try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
+                try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
+                            (mock, context) -> {
+                                when(mock.isOK()).thenReturn(true);
+                                when(mock.getInputString()).thenReturn("image");
+                                when(mock.isChecked()).thenReturn(false);
+                            })) {
+                        try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                            try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                                try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                        (mock, context) -> {
+                                            doNothing().when(mock).start();
+                                        })) {
+                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                    when(kn.getFuncFileURL(any())).thenReturn(mock(URL.class));
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
+                                    messagesMockedStatic.when(() -> Messages.showOkCancelDialog(any(Project.class), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.OK);
+                                    messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                                    action.actionPerformed(anActionEvent);
+                                    Thread.sleep(1000);
+                                    verify(manager, times(1)).start(deployFuncActionPipelineMockedConstruction.constructed().get(0));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasLocalPathAndHasNoFuncFile_UIAskForImage() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+
+        try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
+                try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
+                        (mock, context) -> {
+                            when(mock.isOK()).thenReturn(true);
+                            when(mock.getInputString()).thenReturn("image");
+                            when(mock.isChecked()).thenReturn(false);
+                        })) {
+                    try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                        try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                            try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                    (mock, context) -> {
+                                        doNothing().when(mock).start();
+                                    })) {
+                                treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                messagesMockedStatic.when(() -> Messages.showOkCancelDialog(any(Project.class), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.OK);
+                                messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                                action.actionPerformed(anActionEvent);
+                                Thread.sleep(1000);
+                                assertEquals(1, inputDialogMockedConstruction.constructed().size());
+                                verify(manager, times(1)).start(deployFuncActionPipelineMockedConstruction.constructed().get(0));
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasLocalPathAndFailOpeningFuncFile_UIAskForImage() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+
+        try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
+                try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
+                            (mock, context) -> {
+                                when(mock.isOK()).thenReturn(true);
+                                when(mock.getInputString()).thenReturn("image");
+                                when(mock.isChecked()).thenReturn(false);
+                            })) {
+                        try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                            try(MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                                try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                        (mock, context) -> {
+                                            doNothing().when(mock).start();
+                                        })) {
+                                    treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                    pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                    yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenThrow(new IOException("error"));
+                                    messagesMockedStatic.when(() -> Messages.showOkCancelDialog(any(Project.class), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(Messages.OK);
+                                    messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                                    action.actionPerformed(anActionEvent);
+                                    Thread.sleep(1000);
+                                    assertEquals(1, inputDialogMockedConstruction.constructed().size());
+                                    verify(manager, times(1)).start(deployFuncActionPipelineMockedConstruction.constructed().get(0));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void ActionPerformed_SelectedHasLocalPathAndHasFuncFileWithoutRegistryAndImageSpecifiedAndImageInsertedByUserIsEmptyString_doNothing() throws IOException, InterruptedException {
+        AnAction action = new OnClusterBuildAction();
+        AnActionEvent anActionEvent = createOnClusterBuildActionEvent();
+
+        try(MockedStatic<TreeHelper> treeHelperMockedStatic = mockStatic(TreeHelper.class)) {
+            try (MockedStatic<Paths> pathsMockedStatic = mockStatic(Paths.class)) {
+                try (MockedStatic<YAMLHelper> yamlHelperMockedStatic = mockStatic(YAMLHelper.class)) {
+                    try(MockedConstruction<InputDialogWithCheckbox> inputDialogMockedConstruction = mockConstruction(InputDialogWithCheckbox.class,
+                            (mock, context) -> {
+                                when(mock.isOK()).thenReturn(true);
+                                when(mock.getInputString()).thenReturn("");
+                                when(mock.isChecked()).thenReturn(false);
+                            })) {
+                        try(MockedStatic<Messages> messagesMockedStatic = mockStatic(Messages.class)) {
+                            try (MockedStatic<TelemetryService> telemetryServiceMockedStatic = mockStatic((TelemetryService.class))) {
+                                try (MockedConstruction<FuncActionTask> ignored = mockConstruction(FuncActionTask.class)) {
+                                    try (MockedConstruction<DeployFuncActionPipeline> deployFuncActionPipelineMockedConstruction = mockConstruction(DeployFuncActionPipeline.class,
+                                            (mock, context) -> {
+                                                doNothing().when(mock).start();
+                                            })) {
+                                        treeHelperMockedStatic.when(() -> TreeHelper.getKn(any())).thenReturn(kn);
+                                        pathsMockedStatic.when(() -> Paths.get(anyString(), anyString())).thenReturn(pathFuncFile);
+                                        yamlHelperMockedStatic.when(() -> YAMLHelper.URLToJSON(any())).thenReturn(jsonNode);
+                                        yamlHelperMockedStatic.when(() -> YAMLHelper.JSONToYAML(any())).thenReturn("");
+                                        yamlHelperMockedStatic.when(() -> YAMLHelper.getStringValueFromYAML(anyString(), any(String[].class))).thenReturn("").thenReturn("");
+                                        messagesMockedStatic.when(() -> Messages.showInputDialog(any(Project.class), anyString(), anyString(), any())).thenReturn("repo");
+                                        mockTelemetry(telemetryServiceMockedStatic);
+                                        action.actionPerformed(anActionEvent);
+                                        Thread.sleep(1000);
+                                        assertEquals(0, deployFuncActionPipelineMockedConstruction.constructed().size());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private AnActionEvent createOnClusterBuildActionEvent() throws IOException {
+        AnActionEvent anActionEvent = mock(AnActionEvent.class);
+        when(anActionEvent.getData(PlatformDataKeys.CONTEXT_COMPONENT)).thenReturn(tree);
+        when(tree.getClientProperty(Constants.STRUCTURE_PROPERTY)).thenReturn(knFunctionsTreeStructure);
+        when(knFunctionNode.getRootNode()).thenReturn(knRootNode);
+        when(knFunctionNode.getName()).thenReturn("name");
+        when(knRootNode.getKn()).thenReturn(kn);
+        when(kn.getNamespace()).thenReturn("namespace");
+        when(anActionEvent.getProject()).thenReturn(project);
+        when(model.getSelectionPath()).thenReturn(path3);
+        when(model.getSelectionPaths()).thenReturn(new TreePath[] {path3});
+        when(knFunctionNode.getFunction()).thenReturn(function);
+        when(function.getName()).thenReturn("name");
+
+        when(function.getLocalPath()).thenReturn("path");
+        pathFuncFile = mock(Path.class);
+        File funcFile = mock(File.class);
+        URI uriFuncFile = mock(URI.class);
+        URL urlFuncFile = mock(URL.class);
+        jsonNode = mock(JsonNode.class);
+        when(uriFuncFile.toURL()).thenReturn(urlFuncFile);
+        when(pathFuncFile.toFile()).thenReturn(funcFile);
+        when(funcFile.exists()).thenReturn(true);
+        when(funcFile.toURI()).thenReturn(uriFuncFile);
+
+        return anActionEvent;
+    }
+}

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.BaseTest;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
+import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import io.fabric8.kubernetes.api.model.RootPaths;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -418,8 +419,9 @@ public class KnCliTest extends BaseTest {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
         java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction = mock(java.util.function.Function.class);
+        ImageRegistryModel model = new ImageRegistryModel("", "registry");
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "", terminalExecutionConsole, processHandlerFunction, processListener);
+            kn.buildFunc("path", model, terminalExecutionConsole, processHandlerFunction, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
                             any(TerminalExecutionConsole.class), any(java.util.function.Function.class), any(ProcessListener.class), anyString(),
@@ -433,8 +435,9 @@ public class KnCliTest extends BaseTest {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
         java.util.function.Function<ProcessHandlerInput, ExecProcessHandler> processHandlerFunction = mock(java.util.function.Function.class);
+        ImageRegistryModel model = new ImageRegistryModel("image", "registry");
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.buildFunc("path", "registry", "image", terminalExecutionConsole, processHandlerFunction, processListener);
+            kn.buildFunc("path", model, terminalExecutionConsole, processHandlerFunction, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(eq(null), anyString(), anyMap(),
                             any(TerminalExecutionConsole.class), any(java.util.function.Function.class), any(ProcessListener.class), anyString(),
@@ -447,7 +450,7 @@ public class KnCliTest extends BaseTest {
     public void BuildFunc_ClientFails_Throws() {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             execHelperMockedStatic.when(() -> ExecHelper.executeWithTerminal(any(), anyString())).thenThrow(new IOException("error"));
-            kn.buildFunc("", "", "", null, null, null);
+            kn.buildFunc("", new ImageRegistryModel(), null, null, null);
         } catch (IOException e) {
             assertEquals("error", e.getLocalizedMessage());
         }
@@ -457,8 +460,9 @@ public class KnCliTest extends BaseTest {
     public void DeployFunc_RegistryIsInsertedButNoImage_DeployIsCalled() throws IOException {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
+        ImageRegistryModel model = new ImageRegistryModel("", "registry");
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.deployFunc("namespace", "path", "registry", "", terminalExecutionConsole, processListener);
+            kn.deployFunc("namespace", "path", model, terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole), eq(processListener), anyString(), eq("deploy"), eq("-r"), eq("registry"), eq("-n"), eq("namespace"), eq("-p"), eq("path"), eq("-v"), eq("-b"), eq("disabled")));
         }
@@ -468,8 +472,9 @@ public class KnCliTest extends BaseTest {
     public void DeployFunc_ImageIsInserted_DeployIsCalled() throws IOException {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
+        ImageRegistryModel model = new ImageRegistryModel("image", "registry");
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.deployFunc("namespace", "path", "registry", "image", terminalExecutionConsole, processListener);
+            kn.deployFunc("namespace", "path", model, terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole), eq(processListener), anyString(), eq("deploy"), eq("-i"), eq("image"), eq("-n"), eq("namespace"), eq("-p"), eq("path"), eq("-v"), eq("-b"), eq("disabled")));
         }
@@ -479,7 +484,7 @@ public class KnCliTest extends BaseTest {
     public void DeployFunc_ClientFails_Throws() {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             execHelperMockedStatic.when(() -> ExecHelper.executeWithTerminal(any(), anyString())).thenThrow(new IOException("error"));
-            kn.deployFunc("", "", "", "", null, null);
+            kn.deployFunc("", "", new ImageRegistryModel(), null, null);
         } catch (IOException e) {
             assertEquals("error", e.getLocalizedMessage());
         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.BaseTest;
 import com.redhat.devtools.intellij.knative.ui.createFunc.CreateFuncModel;
+import com.redhat.devtools.intellij.knative.utils.model.GitRepoModel;
 import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
 import com.redhat.devtools.intellij.knative.utils.model.InvokeModel;
 import io.fabric8.kubernetes.api.model.RootPaths;
@@ -495,8 +496,9 @@ public class KnCliTest extends BaseTest {
         TerminalExecutionConsole terminalExecutionConsole = mock(TerminalExecutionConsole.class);
         ProcessListener processListener = mock(ProcessListener.class);
         ImageRegistryModel model = new ImageRegistryModel("image", "");
+        GitRepoModel repoModel = new GitRepoModel("repo");
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.onClusterBuildFunc("namespace", "path", "repo", model, terminalExecutionConsole, processListener);
+            kn.onClusterBuildFunc("namespace", "path", repoModel, model, terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole),
                             eq(processListener), anyString(), eq("deploy"), eq("-i"), eq("image"),
@@ -511,8 +513,9 @@ public class KnCliTest extends BaseTest {
         ProcessListener processListener = mock(ProcessListener.class);
         ImageRegistryModel model = new ImageRegistryModel();
         model.setAutoDiscovery();
+        GitRepoModel repoModel = new GitRepoModel("repo");
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
-            kn.onClusterBuildFunc("namespace", "path", "repo", model, terminalExecutionConsole, processListener);
+            kn.onClusterBuildFunc("namespace", "path", repoModel, model, terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
                     ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole),
                             eq(processListener), anyString(), eq("deploy"), eq("-n"), eq("namespace"),
@@ -525,7 +528,7 @@ public class KnCliTest extends BaseTest {
     public void OnClusterBuildFunc_ClientFails_Throws() {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             execHelperMockedStatic.when(() -> ExecHelper.executeWithTerminal(any(), anyString())).thenThrow(new IOException("error"));
-            kn.onClusterBuildFunc("", "", "", new ImageRegistryModel(), null, null);
+            kn.onClusterBuildFunc("", "", null, new ImageRegistryModel(), null, null);
         } catch (IOException e) {
             assertEquals("error", e.getLocalizedMessage());
         }

--- a/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/kn/KnCliTest.java
@@ -464,7 +464,7 @@ public class KnCliTest extends BaseTest {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             kn.deployFunc("namespace", "path", model, terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
-                    ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole), eq(processListener), anyString(), eq("deploy"), eq("-r"), eq("registry"), eq("-n"), eq("namespace"), eq("-p"), eq("path"), eq("-v"), eq("-b"), eq("disabled")));
+                    ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole), eq(processListener), anyString(), eq("deploy"), eq("-r"), eq("registry"), eq("-n"), eq("namespace"), eq("-p"), eq("path"), eq("-v"), eq("--build"), eq("false")));
         }
     }
 
@@ -476,7 +476,7 @@ public class KnCliTest extends BaseTest {
         try (MockedStatic<ExecHelper> execHelperMockedStatic = mockStatic(ExecHelper.class)) {
             kn.deployFunc("namespace", "path", model, terminalExecutionConsole, processListener);
             execHelperMockedStatic.verify(() ->
-                    ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole), eq(processListener), anyString(), eq("deploy"), eq("-i"), eq("image"), eq("-n"), eq("namespace"), eq("-p"), eq("path"), eq("-v"), eq("-b"), eq("disabled")));
+                    ExecHelper.executeWithTerminal(any(), anyString(), anyMap(), eq(terminalExecutionConsole), eq(processListener), anyString(), eq("deploy"), eq("-i"), eq("image"), eq("-n"), eq("namespace"), eq("-p"), eq("path"), eq("-v"), eq("--build"), eq("false")));
         }
     }
 

--- a/src/test/java/com/redhat/devtools/intellij/knative/utils/ImageRegistryModelTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/knative/utils/ImageRegistryModelTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package com.redhat.devtools.intellij.knative.utils;
+
+import com.redhat.devtools.intellij.knative.utils.model.ImageRegistryModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ImageRegistryModelTest {
+
+    @Test
+    public void IsValid_ImageRegistryModelWithImageSet_True() {
+        ImageRegistryModel model = new ImageRegistryModel("image", "");
+        assertTrue(model.isValid());
+    }
+
+    @Test
+    public void IsValid_ImageRegistryModelWithRegistrySet_True() {
+        ImageRegistryModel model = new ImageRegistryModel("", "registry");
+        assertTrue(model.isValid());
+    }
+
+    @Test
+    public void IsValid_ImageRegistryModelWithAutoDiscovery_True() {
+        ImageRegistryModel model = new ImageRegistryModel();
+        model.setAutoDiscovery();
+        assertTrue(model.isValid());
+    }
+
+    @Test
+    public void IsValid_EmptyImageRegistryModel_False() {
+        ImageRegistryModel model = new ImageRegistryModel();
+        assertFalse(model.isValid());
+    }
+}


### PR DESCRIPTION
it resolves #200 
it needs https://github.com/redhat-developer/intellij-common/pull/165 to work

This extend the deploy action to be run with the `--remote` and `--git-url` flag and support the on-cluster build action.

The feature itself is still a bit unstable from my pov. It failed easily if the env is not set correctly.

What i do to setup it is: start a cluster with clusterBot, install the pipeline 1.8 and serverless operators, create a new project,  install the following tasks
```
REPO=https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.25.0
oc apply -f ${REPO}/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
oc apply -f ${REPO}/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
oc apply -f https://gist.githubusercontent.com/jrangelramos/15cad16980957c19c621e37ec8094cb4/raw/a4007c4defffc35d1da743b5994e7eb372506a05/func-deploy.yaml

```

and the git-clone task 1.7 from the tektonhub
```
kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.7/git-clone.yaml
```

then everything works fine.

I've called the action `on-cluster build` as found in the serverless documentation but it performs a build and deploy action so not sure if we want to rename it for clarity.

![on-cluster-build](https://user-images.githubusercontent.com/49404737/194298264-8fc12a35-874c-4552-bea2-691a97d3da4a.gif)
