### PR TITLE
fix: fix compatibility problems

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion = IU-2023.2
-projectVersion=1.3.5
+projectVersion=1.3.6-SNAPSHOT
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/java/com/redhat/devtools/intellij/knative/func/BuildFuncActionTask.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/func/BuildFuncActionTask.java
@@ -12,8 +12,9 @@ package com.redhat.devtools.intellij.knative.func;
 
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.util.Consumer;
 import com.redhat.devtools.intellij.knative.ui.buildRunDeployWindow.buildFuncWindowTab.BuildFuncPanel;
+
+import java.util.function.Consumer;
 
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_CONTENT_NAME;
 import static com.redhat.devtools.intellij.knative.Constants.BUILDFUNC_TOOLWINDOW_ID;

--- a/src/main/java/com/redhat/devtools/intellij/knative/func/FuncActionPipelineBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/func/FuncActionPipelineBuilder.java
@@ -11,11 +11,11 @@
 package com.redhat.devtools.intellij.knative.func;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.util.Consumer;
 import com.redhat.devtools.intellij.knative.kn.Function;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class FuncActionPipelineBuilder {
 

--- a/src/main/java/com/redhat/devtools/intellij/knative/func/FuncActionTask.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/func/FuncActionTask.java
@@ -15,10 +15,8 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Key;
 import com.intellij.terminal.TerminalExecutionConsole;
 import com.intellij.ui.AnimatedIcon;
-import com.intellij.util.Consumer;
 import com.redhat.devtools.intellij.common.model.ProcessHandlerInput;
 import com.redhat.devtools.intellij.common.utils.ExecProcessHandler;
 import com.redhat.devtools.intellij.knative.kn.Function;
@@ -28,6 +26,7 @@ import javax.swing.Icon;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class FuncActionTask implements IFuncAction {
@@ -51,7 +50,7 @@ public class FuncActionTask implements IFuncAction {
     }
 
     public void doExecute() {
-        this.doExecute.consume(this);
+        this.doExecute.accept(this);
     }
 
     public void init(FuncActionPipeline pipeline) {
@@ -59,8 +58,7 @@ public class FuncActionTask implements IFuncAction {
         stateIcon = new Icon[]{ AllIcons.Actions.Profile };
         state = new String[]{"Waiting to start"};
         TerminalExecutionConsole commonTerminalExecutionConsole = new TerminalExecutionConsole(pipeline.getProject(), null);
-        ProcessListener processListener = buildProcessListener();
-        setProcessListener(processListener);
+        setProcessListener(buildProcessListener());
         setTerminalExecutionConsole(commonTerminalExecutionConsole);
         setProcessHandlerFunction();
     }

--- a/src/main/java/com/redhat/devtools/intellij/knative/func/RunFuncActionTask.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/func/RunFuncActionTask.java
@@ -16,10 +16,10 @@ import com.intellij.execution.process.ProcessListener;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.util.Key;
 import com.intellij.ui.AnimatedIcon;
-import com.intellij.util.Consumer;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class RunFuncActionTask extends FuncActionTask {
@@ -33,6 +33,7 @@ public class RunFuncActionTask extends FuncActionTask {
         this.callbackWhenListeningReady = callbackWhenListeningReady;
     }
 
+    @Override
     protected ProcessListener buildProcessListener() {
         Supplier<FuncActionTask> thisSupplier = () -> this;
         return new ProcessAdapter() {
@@ -59,10 +60,9 @@ public class RunFuncActionTask extends FuncActionTask {
 
             @Override
             public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
-                if (event.getText().contains("Function started on port")) {
-                    if (callbackWhenListeningReady != null) {
+                if (event.getText().contains("Function started on port") && (callbackWhenListeningReady != null)) {
                         callbackWhenListeningReady.run();
-                    }
+
                 }
             }
         };

--- a/src/main/java/com/redhat/devtools/intellij/knative/settings/SettingsState.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/settings/SettingsState.java
@@ -10,8 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.knative.settings;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
@@ -27,7 +27,7 @@ public class SettingsState implements PersistentStateComponent<SettingsState> {
     public String courseVersion = "0.0";
 
     public static SettingsState getInstance() {
-        return ServiceManager.getService(SettingsState.class);
+        return  ApplicationManager.getApplication().getService(SettingsState.class);
     }
 
     @Nullable

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnFunctionDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnFunctionDescriptor.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class KnFunctionDescriptor extends PresentableNodeDescriptor<IKnFunctionNode> {
-    private static final Icon SERVICE_ICON = IconLoader.findIcon("/images/service.svg");
+    private static final Icon SERVICE_ICON = IconLoader.findIcon("/images/service.svg", KnFunctionDescriptor.class);
     private final IKnFunctionNode node;
 
     protected KnFunctionDescriptor(Project project, IKnFunctionNode node, @Nullable NodeDescriptor parentDescriptor) {

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnSinkDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnSinkDescriptor.java
@@ -16,17 +16,13 @@ import com.intellij.ide.util.treeView.PresentableNodeDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.ui.SimpleTextAttributes;
-import com.redhat.devtools.intellij.knative.kn.BaseSource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
 public class KnSinkDescriptor extends PresentableNodeDescriptor<KnSinkNode> {
-    private static final Icon BROKER_ICON = IconLoader.findIcon("/images/broker.svg");
-    private static final Icon CHANNEL_ICON = IconLoader.findIcon("/images/channel.svg");
-    private static final Icon SERVICE_ICON = IconLoader.findIcon("/images/service.svg");
-    private static final Icon LINK_ICON = IconLoader.findIcon("/images/link.svg");
+    private static final Icon SERVICE_ICON = IconLoader.findIcon("/images/service.svg", KnSinkDescriptor.class);
 
     private final KnSinkNode node;
 
@@ -42,13 +38,9 @@ public class KnSinkDescriptor extends PresentableNodeDescriptor<KnSinkNode> {
             presentation.addText("Sink Not Found", SimpleTextAttributes.ERROR_ATTRIBUTES);
         } else {
             presentation.setPresentableText(node.getName());
-            presentation.setIcon(getIcon(node.getSource()));
+            presentation.setIcon(SERVICE_ICON);
         }
 
-    }
-
-    private Icon getIcon(BaseSource source) {
-        return SERVICE_ICON;
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/knative/tree/KnTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/tree/KnTreeStructure.java
@@ -39,9 +39,9 @@ import org.jetbrains.annotations.Nullable;
 
 public class KnTreeStructure extends AbstractKnTreeStructure implements ConfigWatcher.Listener {
 
-    private static final Icon SERVICE_ICON = IconLoader.findIcon("/images/service.svg");
-    private static final Icon REVISION_ICON = IconLoader.findIcon("/images/revision.svg");
-    private static final Icon SOURCE_ICON = IconLoader.findIcon("/images/source-generic.svg");
+    private static final Icon SERVICE_ICON = IconLoader.findIcon("/images/service.svg", KnTreeStructure.class);
+    private static final Icon REVISION_ICON = IconLoader.findIcon("/images/revision.svg", KnTreeStructure.class);
+    private static final Icon SOURCE_ICON = IconLoader.findIcon("/images/source-generic.svg", KnTreeStructure.class);
 
     private final AtomicBoolean initialized = new AtomicBoolean(false);
     private Config config;

--- a/src/main/java/com/redhat/devtools/intellij/knative/ui/CreateServiceDialog.java
+++ b/src/main/java/com/redhat/devtools/intellij/knative/ui/CreateServiceDialog.java
@@ -15,11 +15,11 @@ import com.google.common.base.Strings;
 import com.intellij.CommonBundle;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.colors.EditorFontType;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.fileEditor.impl.text.PsiAwareTextEditorImpl;
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.Divider;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.testFramework.LightVirtualFile;
@@ -31,7 +31,6 @@ import com.intellij.ui.components.JBTabbedPane;
 import com.redhat.devtools.intellij.common.utils.ExecHelper;
 import com.redhat.devtools.intellij.common.utils.UIHelper;
 import com.redhat.devtools.intellij.common.utils.YAMLHelper;
-import com.redhat.devtools.intellij.knative.telemetry.TelemetryService;
 import com.redhat.devtools.intellij.knative.utils.EditorHelper;
 import com.redhat.devtools.intellij.knative.utils.KnHelper;
 import com.redhat.devtools.intellij.knative.utils.UIUtils;
@@ -71,7 +70,6 @@ import java.util.Collection;
 import static com.redhat.devtools.intellij.knative.Constants.YAML_FIRST_IMAGE_PATH;
 import static com.redhat.devtools.intellij.knative.Constants.YAML_NAME_PATH;
 import static com.redhat.devtools.intellij.knative.Constants.borderSearchFieldColor;
-import static com.redhat.devtools.intellij.telemetry.core.util.AnonymizeUtils.anonymizeResource;
 
 public class CreateServiceDialog extends DialogWrapper {
     private final Logger logger = LoggerFactory.getLogger(CreateServiceDialog.class);
@@ -79,7 +77,7 @@ public class CreateServiceDialog extends DialogWrapper {
     private JPanel footerPanel, logPanel;
     private Project project;
     private JButton cancelButton, saveButton;
-    private PsiAwareTextEditorImpl editor;
+    private TextEditor editor;
     private OnePixelSplitter splitterPanel;
     private JTextArea txtAreaEventLog;
     private Runnable refreshFunction;
@@ -374,7 +372,7 @@ public class CreateServiceDialog extends DialogWrapper {
                 try {
                     KnHelper.saveOnCluster(this.project, editor.getEditor().getDocument().getText(), true);
                     UIHelper.executeInUI(refreshFunction);
-                    UIHelper.executeInUI(() -> super.doOKAction());
+                    UIHelper.executeInUI(super::doOKAction);
                     telemetry
                             .success()
                             .send();


### PR DESCRIPTION
extract of plugin verifier message after publishing 1.3.5 : 
```
Knative & Serverless Functions By Red Hat 1.3.5.129 is binary incompatible with IntelliJ IDEA Ultimate IU-231.9392.1 due to the following problems
Method not found (11 problems)
Invocation of unresolved method PsiAwareTextEditorImpl.getEditor() (10 problems)
Method CreateServiceDialog.createLogPanel() contains an invokevirtual instruction referencing an unresolved method PsiAwareTextEditorImpl.getEditor(). This can lead to NoSuchMethodError exception at runtime.
The method might have been declared in the super classes or in the super interfaces:
TextEditorImpl
UserDataHolderBase
Disposable
FileEditor
NavigatableFileEditor
TextEditor
UserDataHolder
UserDataHolderEx
```
those errors were not reported by the `runPluginVerifier` task.

fixed also other reported errors.