### PR TITLE
fix: bump knative- and openshift-client to 7.0-SNAPSHOT (#257)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven { url 'https://repository.jboss.org' }
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 def versionsMap = ['IU-2022.3':'223.7571.175', 'IU-2023.1':'231.8109.91', 'IU-2023.2':'232.8660.158', 'IU-2023.3':'233.11799.7', 'IU-2024.1':'241.14494.19']
@@ -49,8 +50,8 @@ runIdeForUiTests {
 buildSearchableOptions.enabled = false
 
 dependencies {
-    implementation 'io.fabric8:knative-client:6.12.0'
-    implementation 'io.fabric8:openshift-client:6.12.0'
+    implementation 'io.fabric8:knative-client:7.0-SNAPSHOT'
+    implementation 'io.fabric8:openshift-client:7.0-SNAPSHOT'
     implementation 'com.redhat.devtools.intellij:intellij-common:1.9.5'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
     // telemetry contributes annotations 13.0.0, so we need to declare newer version


### PR DESCRIPTION
depends on #259 
fixes #257 